### PR TITLE
Make Peripheral a Sendable value type (Step 2 of 5 for #10)

### DIFF
--- a/Sources/ReliaBLE/BluetoothActor.swift
+++ b/Sources/ReliaBLE/BluetoothActor.swift
@@ -33,10 +33,10 @@ import Foundation
 /// Carries one discovery callback's raw CoreBluetooth payload across the nonisolated
 /// delegate-queue → ``BluetoothActor`` hop.
 ///
-/// The `CBPeripheral` and `[String: Any]` advertisement dictionary delivered by the delegate are non-`Sendable`, but
-/// the payload is read exactly once—on the delegate queue, before the hop—and never mutated, so ferrying it into the
-/// actor is safe. ``Peripheral`` and ``AdvertisementData`` (the `Sendable` value types the app sees) are not
-/// extracted until inside the actor, preserving the invariant that the raw payload is touched only there.
+/// The `CBPeripheral` and `[String: Any]` advertisement dictionary delivered by the delegate are non-`Sendable`.
+/// They are treated as immutable payload and are only accessed inside ``BluetoothActor`` after the hop, where they are
+/// immediately converted into `Sendable` value snapshots (``Peripheral`` / ``AdvertisementData``). The raw payload is
+/// never stored outside the actor.
 ///
 /// This is a single-purpose `@unchecked Sendable` boundary rather than a general-purpose wrapper, so the unchecked
 /// assertion stays scoped to exactly this transfer.

--- a/Sources/ReliaBLE/BluetoothActor.swift
+++ b/Sources/ReliaBLE/BluetoothActor.swift
@@ -30,17 +30,20 @@ import Foundation
 
 // MARK: - Sendable Bridging Helper
 
-/// Wraps a non-`Sendable` value for safe transfer across actor isolation boundaries.
+/// Carries one discovery callback's raw CoreBluetooth payload across the nonisolated
+/// delegate-queue → ``BluetoothActor`` hop.
 ///
-/// The caller must ensure the wrapped value is not mutated concurrently from multiple
-/// isolation domains. This wrapper is used only for the transitional hop between
-/// CoreBluetooth's delegate queue and ``BluetoothActor``.
+/// The `CBPeripheral` and `[String: Any]` advertisement dictionary delivered by the delegate are non-`Sendable`, but
+/// the payload is read exactly once—on the delegate queue, before the hop—and never mutated, so ferrying it into the
+/// actor is safe. ``Peripheral`` and ``AdvertisementData`` (the `Sendable` value types the app sees) are not
+/// extracted until inside the actor, preserving the invariant that the raw payload is touched only there.
 ///
-/// Still required: the raw `CBPeripheral` and `[String: Any]` advertisement dictionary delivered by the delegate
-/// are non-`Sendable` and must cross into the actor. ``Peripheral`` itself is now a `Sendable` value type, but the
-/// CoreBluetooth payload it is built from is not extracted until inside the actor.
-private struct SendableWrapper<T>: @unchecked Sendable {
-    let value: T
+/// This is a single-purpose `@unchecked Sendable` boundary rather than a general-purpose wrapper, so the unchecked
+/// assertion stays scoped to exactly this transfer.
+private struct DiscoveryPayload: @unchecked Sendable {
+    let peripheral: CBPeripheral
+    let advertisementData: [String: Any]
+    let rssi: Int
 }
 
 // MARK: - BluetoothActor
@@ -410,11 +413,16 @@ final class BluetoothDelegateShim: NSObject, CBCentralManagerDelegate {
         advertisementData: [String: Any],
         rssi RSSI: NSNumber
     ) {
-        // Wrap the non-Sendable CBPeripheral and advertisement dictionary for the actor isolation hop.
-        // They are extracted into Sendable types (Peripheral / AdvertisementData) inside the actor.
-        let p = SendableWrapper(value: peripheral)
-        let ad = SendableWrapper(value: advertisementData)
-        let rssi = RSSI.intValue
-        Task { @BluetoothActor in await BluetoothActor.shared.handlePeripheralDiscovered(p.value, advertisementData: ad.value, rssi: rssi) }
+        // Ferry the non-Sendable CBPeripheral and advertisement dictionary across the actor isolation hop in a
+        // single-purpose payload. They are extracted into Sendable types (Peripheral / AdvertisementData) inside
+        // the actor.
+        let payload = DiscoveryPayload(peripheral: peripheral, advertisementData: advertisementData, rssi: RSSI.intValue)
+        Task { @BluetoothActor in
+            await BluetoothActor.shared.handlePeripheralDiscovered(
+                payload.peripheral,
+                advertisementData: payload.advertisementData,
+                rssi: payload.rssi
+            )
+        }
     }
 }

--- a/Sources/ReliaBLE/BluetoothActor.swift
+++ b/Sources/ReliaBLE/BluetoothActor.swift
@@ -36,7 +36,9 @@ import Foundation
 /// isolation domains. This wrapper is used only for the transitional hop between
 /// CoreBluetooth's delegate queue and ``BluetoothActor``.
 ///
-/// **TODO: removed in Step 2** when `Peripheral` becomes a `Sendable` value type.
+/// Still required: the raw `CBPeripheral` and `[String: Any]` advertisement dictionary delivered by the delegate
+/// are non-`Sendable` and must cross into the actor. ``Peripheral`` itself is now a `Sendable` value type, but the
+/// CoreBluetooth payload it is built from is not extracted until inside the actor.
 private struct SendableWrapper<T>: @unchecked Sendable {
     let value: T
 }
@@ -68,7 +70,14 @@ public actor BluetoothActor {
 
     var log: LoggingService?
 
+    /// Value snapshots of all discovered peripherals, keyed implicitly by ``Peripheral/id``.
     var discoveredPeripherals: [Peripheral] = []
+
+    /// Live `CBPeripheral` references keyed by ``Peripheral/id``.
+    ///
+    /// This mutable, non-`Sendable` reference map never escapes the actor. ``Peripheral`` snapshots carry only an
+    /// `id`; operations that need the live peripheral look it up here.
+    private var cbPeripherals: [String: CBPeripheral] = [:]
 
     // Combine subjects — written only from actor-isolated context.
     let stateSubject = CurrentValueSubject<BluetoothState, Never>(.unknown)
@@ -267,48 +276,72 @@ public actor BluetoothActor {
         advertisementData: [String: Any],
         rssi: Int
     ) {
-        // Inlined rather than calling private helpers so that the non-Sendable
-        // CBPeripheral reference never appears at an actor method call site.
-        // The Swift 6 region-based isolation checker reports a false positive
-        // ("please file a bug") when a non-Sendable value is passed to an
-        // actor-isolated method, even from within the same actor.
-        // TODO: Step 2 — refactor once Peripheral is a Sendable value type.
+        // Extract the untyped advertisement dictionary into a typed, Sendable snapshot exactly once. The raw
+        // `[String: Any]` does not leave this actor; the same `AdvertisementData` feeds both the discovery event
+        // and the stored `Peripheral` snapshot.
+        let advertisement = AdvertisementData(rawAdvertisementData: advertisementData)
 
         // Emit lightweight discovery feed.
         // TODO: Implement verbose log level
         discoverySubject.send(
-            PeripheralDiscoveryEvent(peripheral: cbPeripheral, advertisementData: advertisementData, rssi: rssi)
+            PeripheralDiscoveryEvent(cbPeripheral: cbPeripheral, advertisement: advertisement, rssi: rssi)
         )
 
         // TODO: FR-8.5: Unique Identifier from Manufacturing Data — connect to id once implemented
         let identifier = cbPeripheral.name
-            ?? advertisementData[CBAdvertisementDataLocalNameKey] as? String
+            ?? advertisement.localName
             ?? cbPeripheral.identifier.uuidString
 
-        // Check if already discovered by app-provided identifier
-        if let existing = discoveredPeripherals.first(where: { $0.id == identifier }) {
-            existing.update(cbPeripheral: cbPeripheral, advertisementData: advertisementData, rssi: rssi)
-            discoveredPeripheralsSubject.send(discoveredPeripherals)
-            return
+        let cbIdentifier = cbPeripheral.identifier
+        let name = cbPeripheral.name ?? advertisement.localName
+        let now = Date()
+
+        // Resolve the id to store under. Prefer an existing entry matching the app-facing `identifier`; otherwise
+        // fall back to an existing entry for the same `CBPeripheral` (whose resolved `id` may differ if the name has
+        // since changed), preserving that entry's original `id`. Otherwise this is a brand-new peripheral.
+        let resolvedId: String
+        if let idx = discoveredPeripherals.firstIndex(where: { $0.id == identifier }) {
+            resolvedId = identifier
+            discoveredPeripherals[idx] = Peripheral(
+                id: resolvedId,
+                cbIdentifier: cbIdentifier,
+                name: name,
+                rssi: rssi,
+                lastSeen: now,
+                advertisement: advertisement
+            )
+        } else if let idx = discoveredPeripherals.firstIndex(where: { $0.cbIdentifier == cbIdentifier }) {
+            resolvedId = discoveredPeripherals[idx].id
+            discoveredPeripherals[idx] = Peripheral(
+                id: resolvedId,
+                cbIdentifier: cbIdentifier,
+                name: name,
+                rssi: rssi,
+                lastSeen: now,
+                advertisement: advertisement
+            )
+        } else {
+            resolvedId = identifier
+            let new = Peripheral(
+                id: resolvedId,
+                cbIdentifier: cbIdentifier,
+                name: name,
+                rssi: rssi,
+                lastSeen: now,
+                advertisement: advertisement
+            )
+            log?.debug(tags: [.category(.scanning), .peripheral(new.id)], "Adding newly discovered peripheral")
+            discoveredPeripherals.append(new)
         }
 
-        // Check if already discovered by CBPeripheral identifier
-        if let existing = discoveredPeripherals.first(where: { $0.peripheralIdentifier == cbPeripheral.identifier }) {
-            existing.update(cbPeripheral: cbPeripheral, advertisementData: advertisementData, rssi: rssi)
-            discoveredPeripheralsSubject.send(discoveredPeripherals)
-            return
-        }
-
-        let new = Peripheral(id: identifier, peripheral: cbPeripheral, advertisementData: advertisementData, rssi: rssi)
-        log?.debug(tags: [.category(.scanning), .peripheral(new.id)], "Adding newly discovered peripheral")
-        discoveredPeripherals.append(new)
+        // Stash the live reference under the resolved id. Never escapes the actor.
+        cbPeripherals[resolvedId] = cbPeripheral
         discoveredPeripheralsSubject.send(discoveredPeripherals)
     }
 
     private func invalidatePeripherals() {
-        for peripheral in discoveredPeripherals {
-            peripheral.invalidateCBPeripheral()
-        }
+        // The value snapshots hold no CoreBluetooth reference to clear; drop the live registry instead.
+        cbPeripherals.removeAll()
         discoveredPeripheralsSubject.send(discoveredPeripherals)
         log?.debug("Invalidated all peripheral references")
     }
@@ -316,7 +349,7 @@ public actor BluetoothActor {
     private func refreshPeripherals() {
         guard let centralManager else { return }
 
-        let identifiers = discoveredPeripherals.compactMap { $0.peripheralIdentifier }
+        let identifiers = discoveredPeripherals.compactMap { $0.cbIdentifier }
         guard !identifiers.isEmpty else {
             log?.debug("No peripheral identifiers to refresh")
             return
@@ -324,12 +357,36 @@ public actor BluetoothActor {
 
         let retrieved = centralManager.retrievePeripherals(withIdentifiers: identifiers)
         for cbPeripheral in retrieved {
-            if let p = discoveredPeripherals.first(where: { $0.peripheralIdentifier == cbPeripheral.identifier }) {
-                p.update(cbPeripheral: cbPeripheral)
+            if let p = discoveredPeripherals.first(where: { $0.cbIdentifier == cbPeripheral.identifier }) {
+                cbPeripherals[p.id] = cbPeripheral
             }
         }
         discoveredPeripheralsSubject.send(discoveredPeripherals)
         log?.debug("Refreshed \(retrieved.count) peripherals from CBCentralManager")
+    }
+
+    // MARK: - Connection
+
+    /// Initiates a connection to the live peripheral backing the given snapshot `id`.
+    ///
+    /// - Parameter id: The ``Peripheral/id`` of a previously discovered peripheral.
+    /// - Throws: ``PeripheralError/notFound`` if no live `CBPeripheral` is registered for `id` (a stale snapshot).
+    ///
+    /// - Note: This currently only fires the connection request. The full connection lifecycle
+    ///   (didConnect/didDisconnect handling and a connection-state surface) is deferred to a later release.
+    func connect(id: String) throws {
+        guard let cbPeripheral = cbPeripherals[id] else {
+            throw PeripheralError.notFound
+        }
+
+        guard let centralManager else {
+            // Mirrors the start/stopScanning convention: no central manager means there is nothing to act on.
+            // In practice unreachable — the registry is only populated while a central manager exists.
+            log?.warn(tags: [.peripheral(id)], "Attempted to connect without a central manager")
+            return
+        }
+
+        centralManager.connect(cbPeripheral, options: nil)
     }
 }
 
@@ -353,8 +410,8 @@ final class BluetoothDelegateShim: NSObject, CBCentralManagerDelegate {
         advertisementData: [String: Any],
         rssi RSSI: NSNumber
     ) {
-        // Wrap non-Sendable values for the actor isolation hop.
-        // TODO: Step 2 — remove SendableWrapper when Peripheral becomes a Sendable value type.
+        // Wrap the non-Sendable CBPeripheral and advertisement dictionary for the actor isolation hop.
+        // They are extracted into Sendable types (Peripheral / AdvertisementData) inside the actor.
         let p = SendableWrapper(value: peripheral)
         let ad = SendableWrapper(value: advertisementData)
         let rssi = RSSI.intValue

--- a/Sources/ReliaBLE/BluetoothManager.swift
+++ b/Sources/ReliaBLE/BluetoothManager.swift
@@ -120,6 +120,16 @@ class BluetoothManager {
     func stopScanning() async {
         await BluetoothActor.shared.stopScanning()
     }
+
+    // MARK: - Connection
+
+    /// Initiates a connection to the given peripheral.
+    ///
+    /// - Parameter peripheral: A peripheral previously delivered via ``discoveredPeripherals``.
+    /// - Throws: ``PeripheralError/notFound`` if the peripheral is no longer known to the library.
+    func connect(to peripheral: Peripheral) async throws {
+        try await BluetoothActor.shared.connect(id: peripheral.id)
+    }
 }
 
 // MARK: - Public Types

--- a/Sources/ReliaBLE/CBUUID+Sendable.swift
+++ b/Sources/ReliaBLE/CBUUID+Sendable.swift
@@ -1,0 +1,37 @@
+//
+//  CBUUID+Sendable.swift
+//  ReliaBLE
+//
+//  Created by Justin Bergen on 6/13/26.
+//
+//  Copyright (c) 2026 Five3 Apps, LLC <justin@five3apps.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import CoreBluetooth
+
+// `CBUUID` is effectively immutable after initialization — it wraps a fixed 16-, 32-, or 128-bit
+// Bluetooth UUID and exposes no mutating API. Marking it `@unchecked Sendable` lets value types that
+// store `CBUUID` (notably ``AdvertisementData``) be `Sendable` and cross the ``BluetoothActor`` boundary.
+//
+// This declaration lives in the shared source tree, so in the `ReliaBLEMock` target it applies to
+// `CBMUUID` via the `CBUUID = CBMUUID` typealias. If a future version of CoreBluetoothMock declares
+// `CBMUUID: Sendable` upstream, this becomes a redundant-conformance error in that target only; guard
+// it per target at that point.
+extension CBUUID: @retroactive @unchecked Sendable {}

--- a/Sources/ReliaBLE/Documentation.docc/Documentation.md
+++ b/Sources/ReliaBLE/Documentation.docc/Documentation.md
@@ -13,6 +13,13 @@ This is a temporary overview.
 - <doc:GettingStarted>
 - <doc:Logging>
 
+### Peripherals
+
+- ``Peripheral``
+- ``AdvertisementData``
+- ``PeripheralDiscoveryEvent``
+- ``PeripheralError``
+
 ### Concurrency
 
 - ``BluetoothActor``

--- a/Sources/ReliaBLE/Documentation.docc/GettingStarted.md
+++ b/Sources/ReliaBLE/Documentation.docc/GettingStarted.md
@@ -118,3 +118,40 @@ if bleManager.currentState == .ready {
 ```
 
 You can monitor the ``ReliaBLEManager/state`` publisher (as shown in the Authorizing Bluetooth section) to ensure Bluetooth is in the `.ready` state before calling `startScanning()`. Scanning will continue until you explicitly call `stopScanning()` or if Bluetooth becomes unavailable.
+
+## Observing Discovered Peripherals
+
+While scanning, ReliaBLE surfaces results two ways:
+
+- ``ReliaBLEManager/peripheralDiscoveries`` emits a lightweight ``PeripheralDiscoveryEvent`` for every advertisement received — useful when you need to process individual advertisement packets.
+- ``ReliaBLEManager/discoveredPeripherals`` emits the current de-duplicated list of ``Peripheral`` values each time it changes.
+
+A ``Peripheral`` is an immutable, `Sendable` value snapshot: it carries the peripheral's ``Peripheral/id``, ``Peripheral/name``, ``Peripheral/rssi``, ``Peripheral/lastSeen``, and a strongly-typed ``AdvertisementData`` rather than a raw `[String: Any]` dictionary. Because it is a value type, it is safe to hand directly to your UI.
+
+```swift
+bleManager.discoveredPeripherals
+    .receive(on: DispatchQueue.main)
+    .sink { peripherals in
+        for peripheral in peripherals {
+            print(peripheral.name ?? peripheral.id, peripheral.advertisement?.serviceUUIDs ?? [])
+        }
+    }
+    .store(in: &cancellables)
+```
+
+If your app already knows a peripheral's identity ahead of time — for example, a wearable bound to the user's account — you can construct a ``Peripheral`` directly with ``Peripheral/init(id:)``. Such a snapshot has no ``Peripheral/advertisement`` until ReliaBLE matches it against the corresponding device during discovery.
+
+## Connecting to a Peripheral
+
+Pass a discovered ``Peripheral`` to ``ReliaBLEManager/connect(to:)``. The snapshot carries only a stable identifier; ReliaBLE looks up the live CoreBluetooth peripheral it owns internally and initiates the connection.
+
+```swift
+do {
+    try await bleManager.connect(to: peripheral)
+} catch PeripheralError.notFound {
+    // The snapshot is stale — its underlying peripheral reference was invalidated
+    // (for example, after a Bluetooth reset). Re-scan to rediscover it.
+}
+```
+
+- Note: `connect(to:)` currently initiates the connection request only. The full connection lifecycle (connection-state updates and disconnection handling) will arrive in a later release.

--- a/Sources/ReliaBLE/Models/AdvertisementData.swift
+++ b/Sources/ReliaBLE/Models/AdvertisementData.swift
@@ -1,0 +1,80 @@
+//
+//  AdvertisementData.swift
+//  ReliaBLE
+//
+//  Created by Justin Bergen on 6/13/26.
+//
+//  Copyright (c) 2026 Five3 Apps, LLC <justin@five3apps.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import CoreBluetooth
+import Foundation
+
+/// A strongly-typed, `Sendable` snapshot of a peripheral's advertisement data.
+///
+/// CoreBluetooth surfaces advertisement data as a loosely-typed `[String: Any]` dictionary keyed by
+/// `CBAdvertisementData*` constants. ``AdvertisementData`` extracts those values once, at discovery time and inside
+/// ``BluetoothActor``, so the untyped dictionary never crosses the actor boundary into the public surface.
+///
+/// - Note: This is a typed-only representation. Vendor-specific or otherwise non-standard advertisement keys are not
+///   currently surfaced; a raw escape hatch may be added in a future release if needed.
+public struct AdvertisementData: Sendable, Hashable {
+    /// The local name of the peripheral, from `CBAdvertisementDataLocalNameKey`.
+    public let localName: String?
+
+    /// The advertised service UUIDs, from `CBAdvertisementDataServiceUUIDsKey`.
+    public let serviceUUIDs: [CBUUID]
+
+    /// The manufacturer-specific data, from `CBAdvertisementDataManufacturerDataKey`.
+    public let manufacturerData: Data?
+
+    /// The transmit power level, from `CBAdvertisementDataTxPowerLevelKey`.
+    public let txPowerLevel: Int?
+
+    /// Whether the advertising event is connectable, from `CBAdvertisementDataIsConnectable`.
+    public let isConnectable: Bool?
+
+    /// Service-specific advertisement data, keyed by service UUID, from `CBAdvertisementDataServiceDataKey`.
+    public let serviceData: [CBUUID: Data]
+
+    /// Service UUIDs found in the advertisement's overflow area, from `CBAdvertisementDataOverflowServiceUUIDsKey`.
+    public let overflowServiceUUIDs: [CBUUID]
+
+    /// Solicited service UUIDs, from `CBAdvertisementDataSolicitedServiceUUIDsKey`.
+    public let solicitedServiceUUIDs: [CBUUID]
+
+    /// Extracts a typed snapshot from CoreBluetooth's raw advertisement dictionary.
+    ///
+    /// This initializer is intentionally internal: the untyped `[String: Any]` should be extracted exactly once,
+    /// inside ``BluetoothActor``, and never exposed to consumers.
+    ///
+    /// - Parameter rawAdvertisementData: The advertisement dictionary delivered by
+    ///   `centralManager(_:didDiscover:advertisementData:rssi:)`.
+    init(rawAdvertisementData: [String: Any]) {
+        localName = rawAdvertisementData[CBAdvertisementDataLocalNameKey] as? String
+        serviceUUIDs = rawAdvertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID] ?? []
+        manufacturerData = rawAdvertisementData[CBAdvertisementDataManufacturerDataKey] as? Data
+        txPowerLevel = (rawAdvertisementData[CBAdvertisementDataTxPowerLevelKey] as? NSNumber)?.intValue
+        isConnectable = (rawAdvertisementData[CBAdvertisementDataIsConnectable] as? NSNumber)?.boolValue
+        serviceData = rawAdvertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID: Data] ?? [:]
+        overflowServiceUUIDs = rawAdvertisementData[CBAdvertisementDataOverflowServiceUUIDsKey] as? [CBUUID] ?? []
+        solicitedServiceUUIDs = rawAdvertisementData[CBAdvertisementDataSolicitedServiceUUIDsKey] as? [CBUUID] ?? []
+    }
+}

--- a/Sources/ReliaBLE/Models/Events/PeripheralDiscoveryEvent.swift
+++ b/Sources/ReliaBLE/Models/Events/PeripheralDiscoveryEvent.swift
@@ -27,31 +27,26 @@
 import Foundation
 import CoreBluetooth
 
-/// A representation of a discovered Bluetooth peripheral with metadata.
-public struct PeripheralDiscoveryEvent: Identifiable, Hashable {
+/// A lightweight, `Sendable` event emitted for each advertisement received while scanning.
+public struct PeripheralDiscoveryEvent: Identifiable, Hashable, Sendable {
     /// Unique identifier for the peripheral as set by CoreBluetooth
     public let id: UUID
     
     /// The name advertised by the peripheral, if available
     public let name: String?
     
-    /// Advertised service UUIDs
-    public var serviceUUIDs: [CBUUID]? {
-        advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID]
-    }
-    
     /// Signal strength indicator (RSSI)
     public let rssi: Int
     
-    /// Complete advertisement data dictionary from the most recent discovery
-    public let advertisementData: [String: Any]
+    /// The typed advertisement data from this discovery.
+    public let advertisement: AdvertisementData
     
-    /// Create a discovered peripheral from CoreBluetooth information
-    init(peripheral: CBPeripheral, advertisementData: [String: Any], rssi: Int) {
-        self.id = peripheral.identifier
-        self.name = peripheral.name ?? advertisementData[CBAdvertisementDataLocalNameKey] as? String
+    /// Create a discovered peripheral event from CoreBluetooth information.
+    init(cbPeripheral: CBPeripheral, advertisement: AdvertisementData, rssi: Int) {
+        self.id = cbPeripheral.identifier
+        self.name = cbPeripheral.name ?? advertisement.localName
         self.rssi = rssi
-        self.advertisementData = advertisementData
+        self.advertisement = advertisement
     }
     
     public func hash(into hasher: inout Hasher) {

--- a/Sources/ReliaBLE/Models/Peripheral.swift
+++ b/Sources/ReliaBLE/Models/Peripheral.swift
@@ -24,7 +24,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-import CoreBluetooth
 import Foundation
 
 /// An immutable, `Sendable` value snapshot of a Bluetooth peripheral and its metadata.

--- a/Sources/ReliaBLE/Models/Peripheral.swift
+++ b/Sources/ReliaBLE/Models/Peripheral.swift
@@ -27,134 +27,91 @@
 import CoreBluetooth
 import Foundation
 
-/// A representation of a discovered Bluetooth peripheral with metadata.
+/// An immutable, `Sendable` value snapshot of a Bluetooth peripheral and its metadata.
 ///
-/// This peripheral is a wrapper around the CoreBluetooth `CBPeripheral` object and provides additional metadata
-/// and functionality.
+/// A `Peripheral` carries no reference to the underlying CoreBluetooth `CBPeripheral`. The live `CBPeripheral` is
+/// owned exclusively by ``BluetoothActor`` in an `id`-keyed registry that never escapes the actor. Operations that
+/// need the live peripheral (such as ``ReliaBLEManager/connect(to:)``) forward the snapshot's ``id``; the actor looks
+/// up the live reference and throws ``PeripheralError/notFound`` if the snapshot has since gone stale.
 ///
-/// A `Peripheral` can exist without a `CBPeripheral` but all `CBPeripherals` will have a corresponding `Peripheral`.
-/// This allows the integrating app to request communiication with a peripheral prior to it having been discovered
-/// by CoreBluetooth, or if CoreBluetooth has invalidated all of its `CBPeripherals`.
-public final class Peripheral: Identifiable, Hashable, @unchecked Sendable {
-    private let mutationLock = NSLock()
-    
-    /// Unique identifier for the peripheral as set by the integrating app.
-    public let id: String
-    
-    /// The CoreBluetooth peripheral identifier, used to retrieve the peripheral after invalidation.
-    private var _peripheralIdentifier: UUID?
-    var peripheralIdentifier: UUID? {
-        mutationLock.lock(); defer { mutationLock.unlock() }
-        return _peripheralIdentifier
-    }
-    
-    private var _peripheral: CBPeripheral?
-    /// Reference to the CoreBluetooth peripheral object
+/// The integrating app can also construct a `Peripheral` from a known identifier *before* it has been discovered —
+/// for example, a wearable bound to the user's account — using ``init(id:)``. Such a snapshot has no
+/// ``advertisement`` (and no live reference) until ``BluetoothActor`` matches it against a discovered `CBPeripheral`.
+///
+/// Because it is a pure value type, a `Peripheral` is freely sendable across isolation domains and safe to hand to
+/// the integrating app for UI display.
+public struct Peripheral: Sendable, Identifiable, Hashable {
+    /// Unique identifier for the peripheral.
     ///
-    /// - Warning: Intgrating app should not hold a strong reference!
-    var peripheral: CBPeripheral? {
-        mutationLock.lock(); defer { mutationLock.unlock() }
-        
-        return _peripheral
-    }
-    
-    /// The name advertised by the peripheral, if available
-    public var name: String? {
-        // No lock needed here since this is a computed property that accesses `peripheral` and `advertisementData`
-        // which already handle their own synchronization.
-        return peripheral?.name ?? advertisementData?[CBAdvertisementDataLocalNameKey] as? String
-    }
-    
-    /// Advertised service UUIDs
-    public var serviceUUIDs: [CBUUID]? {
-        // No lock needed here since this is a computed property that accesses `advertisementData`
-        // which already handles its own synchronization.
-        advertisementData?[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID]
-    }
-    
-    private var _rssi: Int?
-    /// Signal strength indicator (RSSI) of the most recent advertisement
-    public var rssi: Int? {
-        mutationLock.lock(); defer { mutationLock.unlock() }
-        
-        // Return the cached RSSI value if available.
-        return _rssi
-    }
-    
-    private var _advertisementData: [String: Any]?
-    /// Complete advertisement data dictionary from the most recent discovery
-    public var advertisementData: [String: Any]? {
-        mutationLock.lock(); defer { mutationLock.unlock() }
-        
-        // Return the cached advertisement data if available.
-        return _advertisementData
+    /// When provided by the integrating app via ``init(id:)`` this is the app's own identifier. When resolved at
+    /// discovery time it is the peripheral's advertised name, its local name, or — as a fallback — the CoreBluetooth
+    /// identifier string.
+    public let id: String
 
+    /// The CoreBluetooth identifier for the peripheral, used to retrieve it after invalidation.
+    ///
+    /// `nil` for an app-constructed peripheral that has not yet been discovered.
+    public let cbIdentifier: UUID?
+
+    /// The name advertised by the peripheral, if available.
+    public let name: String?
+
+    /// Signal strength indicator (RSSI) of the most recent advertisement.
+    public let rssi: Int?
+
+    /// The timestamp when the peripheral was last seen.
+    public let lastSeen: Date?
+
+    /// The typed advertisement data from the most recent discovery.
+    ///
+    /// `nil` until the peripheral has been discovered. Advertisement data is transient, per-discovery information; it
+    /// is not the peripheral's connected GATT service catalog.
+    public let advertisement: AdvertisementData?
+
+    /// Registers a known peripheral before it has been discovered.
+    ///
+    /// Use this when the integrating app already has a stable identifier for a peripheral — such as a device bound to
+    /// the user's account — and wants ReliaBLE to match it against the corresponding `CBPeripheral` once discovered.
+    /// The resulting snapshot has no ``cbIdentifier``, ``name``, ``rssi``, ``lastSeen``, or ``advertisement`` until
+    /// discovery populates them.
+    ///
+    /// - Parameter id: The integrating app's unique identifier for the peripheral.
+    public init(id: String) {
+        self.init(id: id, cbIdentifier: nil, name: nil, rssi: nil, lastSeen: nil, advertisement: nil)
     }
-    
-    private var _lastSeen: Date?
-    /// The timestamp when the peripheral was last seen
-    public var lastSeen: Date? {
-        mutationLock.lock(); defer { mutationLock.unlock() }
-        
-        // Return the cached last seen date if available.
-        return _lastSeen
-    }
-    
-    /// Create a peripheral with a unique identifier and optional CoreBluetooth peripheral data. The integrating app
-    /// should use this initializer to create a `Peripheral` instance when it has a unique identifier for a peripheral
-    /// but has not yet discovered the peripheral with CoreBluetooth. ``BluetoothActor`` will update the instance
-    /// with CoreBluetooth data when the peripheral is discovered.
+
+    /// Creates a fully-specified peripheral snapshot. Used internally by ``BluetoothActor`` at discovery time.
+    ///
     /// - Parameters:
-    ///  - id: Unique identifier for the peripheral as set by the integrating app.
-    ///  - peripheral: Reference to the CoreBluetooth `CBPeripheral` object
-    ///  - advertisementData: Complete advertisement data dictionary from the most recent discovery
-    ///  - rssi: Signal strength indicator (RSSI) of the most recent advertisement
-    public init(id: String, peripheral: CBPeripheral? = nil, advertisementData: [String: Any]? = nil, rssi: Int? = nil) {
+    ///   - id: Unique identifier for the peripheral.
+    ///   - cbIdentifier: The CoreBluetooth identifier, used to re-resolve the live peripheral after invalidation.
+    ///   - name: The name advertised by the peripheral, if available.
+    ///   - rssi: Signal strength indicator (RSSI) of the most recent advertisement.
+    ///   - lastSeen: The timestamp when the peripheral was last seen.
+    ///   - advertisement: The typed advertisement data from the most recent discovery.
+    init(
+        id: String,
+        cbIdentifier: UUID? = nil,
+        name: String? = nil,
+        rssi: Int? = nil,
+        lastSeen: Date? = nil,
+        advertisement: AdvertisementData? = nil
+    ) {
         self.id = id
-        
-        mutationLock.name = "Peripheral-\(id)-MutationLock"
-        
-        _peripheral = peripheral
-        _peripheralIdentifier = peripheral?.identifier
-        _rssi = rssi
-        _advertisementData = advertisementData
-        
-        if peripheral != nil && rssi != nil {
-            // Only set the last seen date if we have a valid CBPeripheral and RSSI value.
-            // This indicates that we have received an advertisement from the peripheral.
-            _lastSeen = Date()
-        }
+        self.cbIdentifier = cbIdentifier
+        self.name = name
+        self.rssi = rssi
+        self.lastSeen = lastSeen
+        self.advertisement = advertisement
     }
-    
-    func update(cbPeripheral: CBPeripheral, advertisementData: [String: Any]? = nil, rssi: Int? = nil) {
-        mutationLock.lock(); defer { mutationLock.unlock() }
-        
-        _peripheral = cbPeripheral
-        _peripheralIdentifier = cbPeripheral.identifier
-        _advertisementData = advertisementData
-        _rssi = rssi
-        
-        if rssi != nil {
-            // Only set the last seen date if we have a valid RSSI value.
-            // This indicates that we have received an advertisement from the peripheral.
-            _lastSeen = Date()
-        }
-    }
-    
-    /// Invalidates the CoreBluetooth peripheral reference
-    func invalidateCBPeripheral() {
-        mutationLock.lock(); defer { mutationLock.unlock() }
-        
-        _peripheral = nil
-    }
-    
+
     public func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }
-    
+
     public static func == (lhs: Peripheral, rhs: Peripheral) -> Bool {
-        // No need to compare `CBPeripheral` objects or identifiers, since the `id` is unique and matching between
-        // `Peripheral` and `CBPeripheral` instances are handled internally.
+        // Equality keys on `id` only: the identifier is unique and the matching between `Peripheral` snapshots and
+        // their live `CBPeripheral` is handled internally by ``BluetoothActor``.
         return lhs.id == rhs.id
     }
 }

--- a/Sources/ReliaBLE/Models/PeripheralError.swift
+++ b/Sources/ReliaBLE/Models/PeripheralError.swift
@@ -24,7 +24,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-import Foundation
 
 /// Errors thrown by peripheral operations such as ``ReliaBLEManager/connect(to:)``.
 public enum PeripheralError: Error, Sendable {

--- a/Sources/ReliaBLE/Models/PeripheralError.swift
+++ b/Sources/ReliaBLE/Models/PeripheralError.swift
@@ -1,0 +1,38 @@
+//
+//  PeripheralError.swift
+//  ReliaBLE
+//
+//  Created by Justin Bergen on 6/13/26.
+//
+//  Copyright (c) 2026 Five3 Apps, LLC <justin@five3apps.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import Foundation
+
+/// Errors thrown by peripheral operations such as ``ReliaBLEManager/connect(to:)``.
+public enum PeripheralError: Error, Sendable {
+    /// The peripheral is no longer known to the library.
+    ///
+    /// A ``Peripheral`` is a value snapshot captured at discovery time. The live CoreBluetooth peripheral it refers to
+    /// is held inside ``BluetoothActor`` keyed by ``Peripheral/id``. If that reference has since been invalidated (for
+    /// example, after Bluetooth reset) the snapshot is stale and operations that require the live peripheral throw
+    /// this error.
+    case notFound
+}

--- a/Sources/ReliaBLE/ReliaBLEManager.swift
+++ b/Sources/ReliaBLE/ReliaBLEManager.swift
@@ -102,6 +102,23 @@ public class ReliaBLEManager {
         await bluetoothManager.stopScanning()
     }
     
+    // MARK: - Connection
+
+    /// Initiates a connection to a previously discovered peripheral.
+    ///
+    /// The ``Peripheral`` is a value snapshot captured at discovery time. This method forwards its ``Peripheral/id``
+    /// to the live CoreBluetooth peripheral held internally and requests a connection.
+    ///
+    /// - Parameter peripheral: A peripheral previously delivered via ``discoveredPeripherals``.
+    /// - Throws: ``PeripheralError/notFound`` if the peripheral's live reference has been invalidated (a stale
+    ///   snapshot).
+    ///
+    /// - Note: This currently only initiates the connection request. The full connection lifecycle is deferred to a
+    ///   later release.
+    public func connect(to peripheral: Peripheral) async throws {
+        try await bluetoothManager.connect(to: peripheral)
+    }
+    
     func testFunction() -> String {
         return "Hello, this is ReliaBLE!"
     }

--- a/Tests/ReliaBLETests/ReliaBLEManagerTests.swift
+++ b/Tests/ReliaBLETests/ReliaBLEManagerTests.swift
@@ -32,3 +32,22 @@ import Testing
     let package = ReliaBLEManager()
     #expect(package.testFunction() == "Hello, this is ReliaBLE!", "Incorrect response string")
 }
+
+@Test func peripheralIsSendable() async throws {
+    let peripheral = Peripheral(id: "sendable-id")
+
+    // Capturing the value in a `Task.detached` closure is a compile-time proof that
+    // `Peripheral` is `Sendable` — the closure crosses an isolation boundary.
+    let capturedId = await Task.detached { peripheral.id }.value
+
+    #expect(capturedId == "sendable-id")
+}
+
+@Test func connectToUnknownPeripheralThrowsNotFound() async throws {
+    let manager = ReliaBLEManager()
+    let staleSnapshot = Peripheral(id: "never-discovered")
+
+    await #expect(throws: PeripheralError.self) {
+        try await manager.connect(to: staleSnapshot)
+    }
+}

--- a/Tests/ReliaBLETests/ReliaBLEManagerTests.swift
+++ b/Tests/ReliaBLETests/ReliaBLEManagerTests.swift
@@ -47,7 +47,12 @@ import Testing
     let manager = ReliaBLEManager()
     let staleSnapshot = Peripheral(id: "never-discovered")
 
-    await #expect(throws: PeripheralError.self) {
+    do {
         try await manager.connect(to: staleSnapshot)
+        #expect(false, "Expected PeripheralError.notFound")
+    } catch PeripheralError.notFound {
+        // expected
+    } catch {
+        #expect(false, "Expected PeripheralError.notFound, got \(error)")
     }
 }

--- a/docs/plans/bluetooth-actor-migration-2026-06-08.md
+++ b/docs/plans/bluetooth-actor-migration-2026-06-08.md
@@ -19,6 +19,8 @@ This is **Step 1 of 5**. The public `AnyPublisher` surface and the `Peripheral` 
 **Step handoffs (do not implement here):**
 - Step 2 (#17): `Peripheral` → `Sendable` value struct; `CBPeripheral` registry fully actor-owned
 - Step 3 (#12): Replace `AnyPublisher` with `AsyncStream`; remove all `@unchecked Sendable`/`nonisolated(unsafe)` Combine workarounds from this step
+
+> **Note (added 2026-06-19):** This plan elsewhere assumes the `SendableWrapper` delegate-hop is removed in Step 2. That turned out to be a misattribution — see the as-built addendum in `docs/plans/peripheral-sendable-struct-2026-06-13.md` (items #4 and #8) for why the hop is still required. This plan is left otherwise intact as the original Step 1 intent.
 - Step 4 (#18): `ReliaBLEManager` → `nonisolated Sendable`; collapse `BluetoothManager` into the actor
 - Step 5 (#19): `-strict-concurrency=complete` flag flip + logging polish + DocC
 

--- a/docs/plans/peripheral-sendable-struct-2026-06-13.md
+++ b/docs/plans/peripheral-sendable-struct-2026-06-13.md
@@ -158,6 +158,8 @@ Considered, then rejected, adding `serviceUUIDs` (or an `advertisedServiceUUIDs`
 
 The plan's Background implied the `SendableWrapper` hop might go away once `Peripheral` is a value type. It was **kept**: the raw `CBPeripheral` and `[String: Any]` advertisement dictionary delivered by the delegate are still non-`Sendable` and must cross the delegate-queue → actor hop before extraction into `Peripheral`/`AdvertisementData` *inside* the actor. The doc comments were updated to reflect this.
 
+**Why the Step 1 expectation was wrong.** The Step 1 plan (and the original `SendableWrapper` TODO comments) assumed the wrapper existed to ferry the non-`Sendable` `Peripheral` *class*, so making `Peripheral` a value type would remove it. That was a misattribution: the wrapper never carried a `Peripheral` — it carries the raw `CBPeripheral` and `[String: Any]` advertisement dictionary delivered on CoreBluetooth's nonisolated delegate queue. Those framework types stay non-`Sendable`, the architecture deliberately defers extraction into value types until *inside* the actor, and Step 2's new actor-owned `cbPeripherals: [String: CBPeripheral]` registry actually *requires* the live reference to reach the actor. So the hop survives regardless of `Peripheral`'s Sendability. An oracle review confirmed this and validated keeping the hop (do **not** extract in the shim or pass only a `UUID` — that would violate the invariant and trade a live reference for a racy `retrievePeripherals(withIdentifiers:)` lookup).
+
 ### 5. `CBUUID: @retroactive @unchecked Sendable` — no mock-target collision
 
 The Open Question risk (redundant-conformance error if `CoreBluetoothMock` already declares `CBMUUID: Sendable`) did **not** materialize. Both `ReliaBLE` and `ReliaBLEMock` compile the shared extension cleanly; no per-target guard was needed.
@@ -169,3 +171,11 @@ In addition to the `PeripheralError.notFound` registry-lookup throw, `connect(id
 ### 7. Tests
 
 Shipped as planned: a `Task.detached`-capture `Sendable` proof (`peripheralIsSendable`) and a stale-snapshot `connect` test (`connectToUnknownPeripheralThrowsNotFound`, asserting `PeripheralError.self`). Both use the new `public init(id:)`. A broader actor/registry test harness (driving the mock central to emit discoveries) was noted as a possible follow-up, out of scope here.
+
+### 8. `SendableWrapper<T>` → `DiscoveryPayload`: keep the unchecked scope small (post-merge refinement, 2026-06-19)
+
+The same oracle review from item #4 recommended narrowing the unchecked assertion. The generic `private struct SendableWrapper<T>: @unchecked Sendable` was replaced with a single-purpose `private struct DiscoveryPayload: @unchecked Sendable { let peripheral: CBPeripheral; let advertisementData: [String: Any]; let rssi: Int }` in `BluetoothActor.swift`. The shim now ferries one `DiscoveryPayload` across the hop instead of two generic wrappers.
+
+- **Decision — keep the solution scope small.** A generic `@unchecked Sendable` wrapper reads as a reusable escape hatch: it invites future call sites to bypass concurrency checking for *any* type, which muddies the waters over time and erodes the value of complete concurrency checking. The real invariant is narrow — "this one discovery payload is safe to ferry once into the actor." A single-purpose type names exactly that boundary, makes the unchecked assertion self-documenting, and keeps the unsafe surface confined to the one hop that genuinely needs it rather than normalizing a general-purpose unchecked tool.
+- **No behavior change:** still a `@unchecked Sendable` ferry of the raw, read-once CoreBluetooth payload; extraction into `Peripheral`/`AdvertisementData` still happens inside the actor. Builds clean under `ReliaBLE` and `ReliaBLEMock`.
+- **Not a Step 3 obligation:** the oracle confirmed AsyncStream cleanup (Step 3) removes the Combine `nonisolated(unsafe)` bridging, but does not inherently solve the non-`Sendable` CoreBluetooth payload hop. A future switch to `sending` parameters would be a targeted, compiler-verified refactor rather than a required goal.

--- a/docs/plans/peripheral-sendable-struct-2026-06-13.md
+++ b/docs/plans/peripheral-sendable-struct-2026-06-13.md
@@ -1,0 +1,171 @@
+# Peripheral → Sendable Value Struct + AdvertisementData: Plan (Step 2 of 5)
+*Issue #17 · 2026-06-13*
+
+## Goal
+
+Replace the `@unchecked Sendable` `Peripheral` class — which leaks `CBPeripheral?` and `[String: Any]?` through its public surface under a false `Sendable` promise — with a true `Sendable` value struct. Introduce a strongly-typed `AdvertisementData` struct to replace `[String: Any]`. Keep the live `CBPeripheral` reference inside `BluetoothActor` in an `id`-keyed registry that never escapes the actor. Add `id`-based operation entry points (`connect(to:)`) that throw `PeripheralError.notFound` on a stale snapshot. Fixes **Cluster 3** of the Swift 6 concurrency audit.
+
+This is **Step 2 of 5**. Combine → AsyncStream is Step 3 (#12); `ReliaBLEManager` `Sendable` conformance is Step 4 (#18). The `AnyPublisher` surface stays in this PR.
+
+## Background
+
+Step 1 (#13) is merged: `@globalActor BluetoothActor` and `BluetoothDelegateShim` already exist and own all BLE state. There is **no** `PeripheralManager` class in the library — the issue's item #4 refers to work already absorbed into `BluetoothActor` in Step 1. The registry today is the actor's `discoveredPeripherals: [Peripheral]` array.
+
+**Current `Peripheral`** (`Sources/ReliaBLE/Models/Peripheral.swift`):
+- `public final class Peripheral: Identifiable, Hashable, @unchecked Sendable`, NSLock-guarded.
+- Stored: `id: String`, `_peripheralIdentifier: UUID?`, `_peripheral: CBPeripheral?`, `_rssi: Int?`, `_advertisementData: [String: Any]?`, `_lastSeen: Date?`.
+- Computed: `name` (falls back to `advertisementData[CBAdvertisementDataLocalNameKey]`), `serviceUUIDs` (from `advertisementData[CBAdvertisementDataServiceUUIDsKey]`).
+- Mutation API: `init(id:peripheral:advertisementData:rssi:)`, `update(cbPeripheral:advertisementData:rssi:)` (:129), `invalidateCBPeripheral()` (:145).
+- Equality/hash already key on `id` only.
+
+**Discovery flow** (`Sources/ReliaBLE/BluetoothActor.swift`):
+- `BluetoothDelegateShim.centralManager(_:didDiscover:advertisementData:rssi:)` (:344) wraps non-Sendable values in `SendableWrapper` and hops to the actor.
+- `handlePeripheralDiscovered(_:advertisementData:rssi:)` (:266–305): builds `PeripheralDiscoveryEvent` (:280) from raw `[String: Any]`; derives `identifier = cbPeripheral.name ?? advertisementData[localName] ?? cbPeripheral.identifier.uuidString`; looks up an existing `Peripheral` by `id`/`peripheralIdentifier` and calls `update(...)`, else constructs a new `Peripheral` (:302) and appends + publishes.
+- `refreshPeripherals()` (:~326) obtains `CBPeripheral`s via `centralManager.retrievePeripherals(withIdentifiers:)` and calls `update(...)`.
+
+**Public surface today** (`ReliaBLEManager.swift`): `state`, `currentState`, `authorizeBluetooth()`, `peripheralDiscoveries: AnyPublisher<PeripheralDiscoveryEvent, Never>`, `discoveredPeripherals: AnyPublisher<[Peripheral], Never>`, `startScanning(services:)`, `stopScanning()`. **No** `connect`/`disconnect` exists anywhere in the library yet.
+
+**`PeripheralDiscoveryEvent`** (`Models/Events/PeripheralDiscoveryEvent.swift`): public struct, also stores `advertisementData: [String: Any]` (:49) with computed `serviceUUIDs` (:39). It does *not* wrap a `Peripheral`. This is a **second** `[String: Any]` leak in the public surface, converted to `AdvertisementData` in this issue.
+
+**Errors**: only `AuthorizationError` exists (`BluetoothManager.swift:197`). No `PeripheralError`.
+
+**Mock target**: `CoreBluetoothMockAliases.swift` already aliases `CBUUID = CBMUUID` (:42) and `CBPeripheral = CBMPeripheral`. There are **zero** `@retroactive`/retroactive-`Sendable` conformances anywhere in `Sources/`.
+
+## Approach
+
+### `Peripheral` → pure value struct
+
+```swift
+public struct Peripheral: Sendable, Identifiable, Hashable {
+    public let id: String           // app-supplied or CB UUID string
+    public let cbIdentifier: UUID?  // CB's own identifier, for retrieval
+    public let name: String?
+    public let rssi: Int?
+    public let lastSeen: Date?
+    public let advertisement: AdvertisementData?  // nil until discovered (see Addendum)
+
+    public init(id: String)  // app-facing pre-discovery construction (see Addendum)
+    // internal full init used by BluetoothActor at discovery time
+}
+```
+
+- No `CBPeripheral`, no `[String: Any]`, no `NSLock`. `Equatable`/`Hashable` key on `id` only (matches today; lets `AdvertisementData` stay out of the hash — see below).
+- `name` becomes a stored field, resolved once at discovery time (`cbPeripheral.name ?? advertisement.localName`).
+- `cbIdentifier` replaces the internal `peripheralIdentifier`; it is the lookup bridge back to the live `CBPeripheral`.
+- **As-built:** `advertisement` shipped as `AdvertisementData?` and a `public init(id:)` was restored — see the Addendum at the end of this document.
+
+### `AdvertisementData` — strongly-typed, extracted once
+
+```swift
+public struct AdvertisementData: Sendable, Hashable {
+    public let localName: String?
+    public let serviceUUIDs: [CBUUID]
+    public let manufacturerData: Data?
+    public let txPowerLevel: Int?
+    public let isConnectable: Bool?
+    public let serviceData: [CBUUID: Data]
+    public let overflowServiceUUIDs: [CBUUID]
+    public let solicitedServiceUUIDs: [CBUUID]
+}
+```
+
+A single internal `init(rawAdvertisementData: [String: Any])` performs all `CBAdvertisementData*Key` extraction at discovery time, inside the actor. `[String: Any]` never leaves the actor.
+
+**Decision:** typed-only for now — no `rawAdvertisement: [String: any Sendable]` hatch. A dict of `any Sendable` is neither `Hashable` nor `Equatable` and would force hand-rolled conformance or dropping `Hashable`; the clean typed surface ships now and a raw hatch can be added in a follow-up if integrators need vendor-extension keys.
+
+### `CBPeripheral` registry inside `BluetoothActor`
+
+Add an actor-private `var cbPeripherals: [String: CBPeripheral] = [:]` keyed by `Peripheral.id`. The mutable reference never escapes the actor. The existing `discoveredPeripherals` array stays `[Peripheral]` (now value snapshots). Three existing paths must change together (all in the same PR, or the build breaks):
+
+- **`handlePeripheralDiscovered`** (:266–305): today the two lookups (`$0.id == identifier`, then `$0.peripheralIdentifier == cbPeripheral.identifier`) call `existing.update(...)`. With value structs, find the index and **replace** (`discoveredPeripherals[idx] = rebuilt`), and set `cbPeripherals[id] = cbPeripheral`. The lookup-before-append already guarantees `id` uniqueness, so the array stays duplicate-free. The method's hand-inlining (and its `// TODO: Step 2 — refactor once Peripheral is a Sendable value type` note) exists only because `CBPeripheral` couldn't cross actor-method boundaries; with the value struct, extraction can move into a shared helper.
+- **`invalidatePeripherals`** (:318): drops the `peripheral.invalidateCBPeripheral()` loop — it becomes `cbPeripherals.removeAll()` (the value snapshots hold no CB ref to clear), then re-emit.
+- **`refreshPeripherals`** (:326): replace `peripheralIdentifier`/`p.update(cbPeripheral:)` with `cbIdentifier`-based retrieval that re-populates `cbPeripherals[id] = cbPeripheral` for matching entries. No struct mutation.
+
+### `id`-keyed operations + `PeripheralError`
+
+```swift
+public enum PeripheralError: Error, Sendable { case notFound }
+
+// ReliaBLEManager
+public func connect(to peripheral: Peripheral) async throws
+
+// BluetoothActor
+func connect(id: String) async throws {
+    guard let cb = cbPeripherals[id] else { throw PeripheralError.notFound }
+    centralManager?.connect(cb, options: nil)
+}
+```
+
+`connect(to:)` forwards the stable `id`; the actor looks up the live `CBPeripheral` and throws `PeripheralError.notFound` if the registry no longer holds it (stale snapshot after invalidation). **Decision:** scope is the entry point + lookup + `notFound` only — `centralManager.connect(cb, options: nil)` is fired, but the full connection lifecycle (didConnect/didDisconnect handling, a connection-state surface) is deferred to a later issue.
+
+### `CBUUID: Sendable`
+
+Add `extension CBUUID: @retroactive @unchecked Sendable {}` with a comment that `CBUUID` is effectively immutable after init. **Risk:** in `ReliaBLEMock`, `CBUUID` resolves to `CBMUUID`; if Nordic already declares `CBMUUID: Sendable`, the extension is a redundant-conformance compile error in that target. Verify per target; guard with a parallel/conditional declaration only if needed.
+
+## Work Items
+
+1. **`AdvertisementData`** — new file `Sources/ReliaBLE/Models/AdvertisementData.swift`. Struct + internal `init(rawAdvertisementData: [String: Any])` doing all key extraction (localName, serviceUUIDs, manufacturerData, txPowerLevel, isConnectable, serviceData, overflow/solicited UUIDs). Typed-only, clean `Hashable` — no raw escape hatch. **Build this first** — Items 5 and 7 both consume the same extraction (build the `AdvertisementData` once in `handlePeripheralDiscovered`, feed it to both the `Peripheral` and the event).
+2. **`CBUUID` Sendable** — add the `@retroactive @unchecked Sendable` extension (own small file, e.g. `Sources/ReliaBLE/CBUUID+Sendable.swift`). It lives in the **shared** source tree (no `Package.swift` exclusion like `CBCentralManagerFactory.swift`), so in `ReliaBLEMock` it applies to `CBMUUID` via the existing `CBUUID = CBMUUID` alias. Build both targets; **if** Nordic already declares `CBMUUID: Sendable` the extension is a redundant-conformance error in the mock target — only then guard it (e.g. `#if`/move the mock-side declaration into `CoreBluetoothMockAliases.swift`).
+3. **`Peripheral` struct rewrite** — replace the class in `Peripheral.swift`. Remove NSLock, `_peripheral`, `update`, `invalidateCBPeripheral`. New stored fields per Approach. Keep `Identifiable`/`Hashable` (by `id`).
+4. **`PeripheralError`** — add `public enum PeripheralError: Error, Sendable { case notFound }` (new file or alongside `AuthorizationError`).
+5. **`BluetoothActor` rewrite of discovery** — add the `cbPeripherals: [String: CBPeripheral]` registry and rewrite all three paths per Approach: `handlePeripheralDiscovered` (extract once, replace-by-index, set registry), `invalidatePeripherals` (clear registry), `refreshPeripherals` (use `cbIdentifier`, repopulate registry). These must land in the same PR — they currently call the class-only `update()`/`invalidateCBPeripheral()`/`peripheralIdentifier`, which all disappear.
+6. **`connect(to:)` entry points** — add `connect(id:)` (and the registry lookup + `PeripheralError.notFound`) on `BluetoothActor`; expose `connect(to:)` on `ReliaBLEManager`. Entry-point-only (no connection lifecycle) per Decision 3.
+7. **`PeripheralDiscoveryEvent`** — replace `advertisementData: [String: Any]` with `advertisement: AdvertisementData`; drop the computed `serviceUUIDs` (now on `AdvertisementData`). Build it from the same extracted `AdvertisementData` in `handlePeripheralDiscovered`. Demo reads only `.id`/`.name`/`.rssi` — unaffected.
+8. **Unit test** — capture a `Peripheral` inside a `Task.detached` closure (compile-time `Sendable` proof); assert `connect` on a stale id throws `PeripheralError.notFound`.
+9. **Verify + docs** — `swift build` + `swift test` for `ReliaBLE`, `ReliaBLEMock`, `ReliaBLETests`; confirm the Demo still builds (it reads only `.id`/`.name`/`.lastSeen` + event `.id`/`.name`/`.rssi`, all preserved). Confirm no `CBPeripheral` / `[String: Any]` in any public type. Update the DocC catalog for the new public surface (`Peripheral`, `AdvertisementData`, `connect(to:)`, `PeripheralError`) per the project's DocC rule.
+
+## Decisions (resolved at planning)
+
+1. **`PeripheralDiscoveryEvent` is converted in #17** — its `[String: Any]` becomes `AdvertisementData`, honoring "no `[String: Any]` in any public type."
+2. **`AdvertisementData` is typed-only** — no `rawAdvertisement` escape hatch (would break `Hashable`); a raw hatch is a possible follow-up.
+3. **`connect(to:)` is entry-point-only** — lookup + `centralManager.connect` + `PeripheralError.notFound`; full connection lifecycle deferred to a later issue.
+
+## Open Questions
+
+None blocking. One implementation-time risk: the `CBUUID: @retroactive @unchecked Sendable` extension may collide with an upstream `CBMUUID: Sendable` in `ReliaBLEMock` (redundant conformance). Resolve at the build step (Work Item 2) — guard per target only if the error appears.
+
+## References
+
+- Investigation report: `docs/investigations/swift6-concurrency-audit-2026-05-13.md` — §3, Cluster 3, Recommendations §B (target design at lines ~697–760).
+- Step 1 plan: `docs/plans/bluetooth-actor-migration-2026-06-08.md`
+- Issue #17 (this); parent #10; depends on #13 (merged, PR #23). Hands off to #12 (Step 3) and #18 (Step 4).
+- Key files: `Sources/ReliaBLE/Models/Peripheral.swift`, `Sources/ReliaBLE/BluetoothActor.swift` (:266–305, :326, :344), `Sources/ReliaBLE/Models/Events/PeripheralDiscoveryEvent.swift`, `Sources/ReliaBLE/ReliaBLEManager.swift`, `Sources/ReliaBLEMock/CoreBluetoothMockAliases.swift`.
+
+## Addendum — As-Built Notes (2026-06-15)
+
+Records where the shipped implementation deviates from or clarifies the plan above. The plan body is left intact as the original intent; this section is authoritative where the two differ.
+
+### 1. `Peripheral` is publicly constructible (reversed from the original cut)
+
+The original draft made all initializers internal, which removed the old `public init`. This was reversed during review:
+
+- Added **`public init(id: String)`** so an integrating app can register a known peripheral *before* discovery — e.g. a wearable bound to the user's account — to be matched against its `CBPeripheral` once discovered (the FR-8.5 custom-advertised-ID path, still unimplemented).
+- The fully-specified initializer (`id:cbIdentifier:name:rssi:lastSeen:advertisement:`) remains **internal**, used only by `BluetoothActor` at discovery time.
+- `AdvertisementData.init(rawAdvertisementData:)` remains **internal** — the "extract the `[String: Any]` exactly once, inside the actor" invariant is preserved. Apps construct a `Peripheral` by `id`; only the library ever builds an `AdvertisementData`.
+
+### 2. `Peripheral.advertisement` is optional (`AdvertisementData?`)
+
+Because an app-constructed, pre-discovery `Peripheral` has no advertisement yet, `advertisement` shipped as `AdvertisementData?` (`nil` until discovery populates it). This honestly distinguishes "not yet seen advertising" from "advertised nothing," and avoids needing a public empty `AdvertisementData` initializer. Likewise `cbIdentifier`/`name`/`rssi`/`lastSeen` are empty on an app-constructed snapshot.
+
+- `PeripheralDiscoveryEvent.advertisement` stays **non-optional** — an event always originates from a received advertisement packet.
+- Consumer impact: reading advertisement off a discovered peripheral now optional-chains, e.g. `peripheral.advertisement?.serviceUUIDs ?? []`.
+
+### 3. Service UUIDs stay on `AdvertisementData` (Work Item 7 confirmed, no convenience accessor)
+
+Considered, then rejected, adding `serviceUUIDs` (or an `advertisedServiceUUIDs` convenience) onto `Peripheral`. Rationale: advertised service UUIDs are a pre-connection *hint* from the advertisement packet and are distinct from `CBPeripheral.services` (the post-connection GATT catalog). Keeping them on `advertisement` (alongside `overflowServiceUUIDs`/`solicitedServiceUUIDs`) leaves `Peripheral.services` free to mean the real connected GATT catalog in a future connection-lifecycle step.
+
+### 4. `SendableWrapper` retained (not removed in Step 2)
+
+The plan's Background implied the `SendableWrapper` hop might go away once `Peripheral` is a value type. It was **kept**: the raw `CBPeripheral` and `[String: Any]` advertisement dictionary delivered by the delegate are still non-`Sendable` and must cross the delegate-queue → actor hop before extraction into `Peripheral`/`AdvertisementData` *inside* the actor. The doc comments were updated to reflect this.
+
+### 5. `CBUUID: @retroactive @unchecked Sendable` — no mock-target collision
+
+The Open Question risk (redundant-conformance error if `CoreBluetoothMock` already declares `CBMUUID: Sendable`) did **not** materialize. Both `ReliaBLE` and `ReliaBLEMock` compile the shared extension cleanly; no per-target guard was needed.
+
+### 6. `connect(id:)` guards a missing central manager
+
+In addition to the `PeripheralError.notFound` registry-lookup throw, `connect(id:)` guards `centralManager == nil` with a log-and-no-op, matching the existing `startScanning`/`stopScanning` convention. In practice unreachable (the registry is only populated while a central manager exists), but it prevents the API from silently reporting success with nothing to act on.
+
+### 7. Tests
+
+Shipped as planned: a `Task.detached`-capture `Sendable` proof (`peripheralIsSendable`) and a stale-snapshot `connect` test (`connectToUnknownPeripheralThrowsNotFound`, asserting `PeripheralError.self`). Both use the new `public init(id:)`. A broader actor/registry test harness (driving the mock central to emit discoveries) was noted as a possible follow-up, out of scope here.

--- a/docs/reviews/peripheral-sendable-struct-plan-critique-2026-06-13.md
+++ b/docs/reviews/peripheral-sendable-struct-plan-critique-2026-06-13.md
@@ -1,0 +1,33 @@
+# Critique: Peripheral → Sendable Value Struct Plan (2026-06-13)
+
+**Scope**: Plan for ReliaBLE #17 (Peripheral value struct + AdvertisementData + CBPeripheral registry). Review limited to the three named seams.
+
+## 1. Under-specified Seams
+
+**handlePeripheralDiscovered rebuild + registry sync** (`BluetoothActor.swift:266-305`)
+- Current code mutates in place via `existing.update(...)` and `discoveredPeripherals.append(new)`. Plan says "rebuild value Peripheral, replace element" but never states the exact lookup/replacement logic or how `cbPeripherals[id] = cbPeripheral` is kept consistent with the two identifier checks (`id` vs `peripheralIdentifier`).
+- `invalidatePeripherals()` (318) and `refreshPeripherals()` (326) still call the old class methods; plan gives no replacement for either path. `refreshPeripherals` uses `peripheralIdentifier` which disappears from the value struct, so the `identifiers` collection and the subsequent `first(where:)` will break.
+
+**discoveredPeripherals: AnyPublisher emission**
+- Plan claims value-semantic snapshots "rebuilt by replacing elements" will keep the publisher working. It does not address whether `discoveredPeripheralsSubject.send(discoveredPeripherals)` (called after every mutation today) still fires correctly when the array contains immutable structs, or whether duplicate `id` entries can appear after a replacement.
+
+**CBUUID retroactive Sendable vs CBMUUID collision**
+- Plan correctly flags the risk in the mock target. It does not state where the guarded declaration lives or whether the production `CBUUID+Sendable.swift` must be excluded from `ReliaBLEMock` target the same way `CBCentralManagerFactory.swift` is.
+
+## 2. Contradictions / Missing Dependencies
+
+- Work Item 5 requires `cbPeripherals` registry, yet the current `invalidatePeripherals`/`refreshPeripherals` paths (already merged in Step 1) are not listed as dependents. They must be rewritten in the same PR or the build will be broken.
+- `PeripheralDiscoveryEvent` conversion (Work Item 7) depends on `AdvertisementData` (Item 1) but also on the same extraction code inside `handlePeripheralDiscovered`. No ordering or shared helper is declared.
+- `PeripheralError` (Item 4) is required for `connect(to:)` (Item 6), but `connect` is the only consumer; if Item 6 slips, Item 4 is dead weight.
+
+## 3. Over-planning
+
+- Work Item 8 ("Demo adaptation") can be deleted. The plan already asserts that `CentralViewModel` only reads `.id`/`.name`/`.lastSeen` and `.rssi`, all of which survive the struct rewrite. No signature change touches the demo.
+- Work Item 10's DocC update is boilerplate; it belongs in the PR description, not a tracked work item.
+
+## 4. Questions That Change Implementation Order
+
+- Must `invalidatePeripherals` and `refreshPeripherals` be rewritten before or after the `Peripheral` struct change? If the registry must stay in sync on power-cycle, the order is forced.
+- Is `discoveredPeripheralsSubject` allowed to emit duplicate `id` values after a replacement, or must the plan guarantee uniqueness? The answer determines whether a dictionary or array-with-replace is used.
+
+**Recommendation**: Resolve the three seams above and delete Work Items 8 and 10 before scheduling.


### PR DESCRIPTION
Plan: /docs/plans/peripheral-sendable-struct-2026-06-13.md
Plan Critique: /docs/reviews/peripheral-sendable-struct-plan-critique-2026-06-13.md

Convert `Peripheral` from a reference-wrapping type into an immutable, `Sendable` value snapshot that carries no `CBPeripheral` reference. The live `CBPeripheral` is now owned exclusively by `BluetoothActor` in an `id`-keyed registry that never escapes the actor; operations forward the snapshot's `id` and the actor resolves the live reference, throwing `PeripheralError.notFound` when a snapshot has gone stale.

- Add `AdvertisementData` to expose typed advertisement fields as values
- Add `PeripheralError` for stale/unresolvable snapshot lookups
- Add `CBUUID+Sendable` retroactive conformance
- Let apps pre-register a known peripheral via `Peripheral(id:)`
- Update `BluetoothActor` discovery to snapshot values and retain the non-`Sendable` CoreBluetooth payload only inside the actor
- Update DocC and tests for the new value-type API

Closes #17 