### PR TITLE
Replace Combine event surfaces with AsyncStream broadcaster (Step 3 of 5, #10)

### DIFF
--- a/Demo/ReliaBLE Demo/ReliaBLE Demo/Central/CentralView.swift
+++ b/Demo/ReliaBLE Demo/ReliaBLE Demo/Central/CentralView.swift
@@ -24,7 +24,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-import Combine
 import CoreBluetooth
 import SwiftUI
 import SwiftData
@@ -98,8 +97,20 @@ struct CentralView: View {
         .onAppear {
             viewModel.setDependencies(modelContext: modelContext, reliaBLE: reliaBLE)
         }
-        .onDisappear {
-            viewModel.cancellables.removeAll()
+        .task {
+            for await state in reliaBLE.state {
+                viewModel.updateState(state)
+            }
+        }
+        .task {
+            for await discoveryEvent in reliaBLE.peripheralDiscoveries {
+                viewModel.insertDiscovery(discoveryEvent, into: modelContext)
+            }
+        }
+        .task {
+            for await peripherals in reliaBLE.discoveredPeripherals {
+                viewModel.syncDevices(peripherals, into: modelContext)
+            }
         }
     }
     

--- a/Demo/ReliaBLE Demo/ReliaBLE Demo/Central/CentralViewModel.swift
+++ b/Demo/ReliaBLE Demo/ReliaBLE Demo/Central/CentralViewModel.swift
@@ -24,7 +24,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-import Combine
 import CoreBluetooth
 import SwiftData
 import SwiftUI
@@ -35,60 +34,53 @@ import ReliaBLE
     var currentState: BluetoothState = .unknown
     var servicesInput = ""
     
-    var cancellables = Set<AnyCancellable>()
-    
     private var modelContext: ModelContext?
     private var reliaBLE: ReliaBLEManager?
     
     func setDependencies(modelContext: ModelContext, reliaBLE: ReliaBLEManager) {
         self.modelContext = modelContext
         self.reliaBLE = reliaBLE
-        
-        setupSubscriptions()
     }
     
-    private func setupSubscriptions() {
-        guard let reliaBLE = reliaBLE, let modelContext = modelContext else { return }
-        
-        reliaBLE.state
-            .receive(on: DispatchQueue.main)
-            .assign(to: \.currentState, on: self)
-            .store(in: &cancellables)
-        
-        reliaBLE.peripheralDiscoveries
-            .receive(on: DispatchQueue.main)
-            .sink { discoveryEvent in
-                let event = DiscoveryEvent(
-                    peripheralIdentifier: discoveryEvent.id.uuidString,
-                    name: discoveryEvent.name ?? "Unknown",
-                    rssi: discoveryEvent.rssi,
-                    timestamp: Date()
-                )
-                modelContext.insert(event)
-                try? modelContext.save()
-            }
-            .store(in: &cancellables)
-
-        reliaBLE.discoveredPeripherals
-            .receive(on: DispatchQueue.main)
-            .sink { peripherals in
-                do {
-                    let allDevices = try modelContext.fetch(FetchDescriptor<Device>())
-                    for peripheral in peripherals {
-                        if let existingDevice = allDevices.first(where: { $0.id == peripheral.id }) {
-                            existingDevice.name = peripheral.name
-                            existingDevice.lastSeen = peripheral.lastSeen
-                        } else {
-                            let newDevice = Device(id: peripheral.id, name: peripheral.name, lastSeen: Date())
-                            modelContext.insert(newDevice)
-                        }
-                    }
-                    try modelContext.save()
-                } catch {
-                    print("Error fetching devices: \(error)")
+    // MARK: - Stream Handlers
+    //
+    // Fed by the `.task { for await … }` loops in `CentralView`. Each handler runs on the main
+    // actor before touching `@Observable` state or SwiftData.
+    
+    @MainActor
+    func updateState(_ state: BluetoothState) {
+        currentState = state
+    }
+    
+    @MainActor
+    func insertDiscovery(_ discoveryEvent: PeripheralDiscoveryEvent, into modelContext: ModelContext) {
+        let event = DiscoveryEvent(
+            peripheralIdentifier: discoveryEvent.id.uuidString,
+            name: discoveryEvent.name ?? "Unknown",
+            rssi: discoveryEvent.rssi,
+            timestamp: Date()
+        )
+        modelContext.insert(event)
+        try? modelContext.save()
+    }
+    
+    @MainActor
+    func syncDevices(_ peripherals: [Peripheral], into modelContext: ModelContext) {
+        do {
+            let allDevices = try modelContext.fetch(FetchDescriptor<Device>())
+            for peripheral in peripherals {
+                if let existingDevice = allDevices.first(where: { $0.id == peripheral.id }) {
+                    existingDevice.name = peripheral.name
+                    existingDevice.lastSeen = peripheral.lastSeen
+                } else {
+                    let newDevice = Device(id: peripheral.id, name: peripheral.name, lastSeen: Date())
+                    modelContext.insert(newDevice)
                 }
             }
-            .store(in: &cancellables)
+            try modelContext.save()
+        } catch {
+            print("Error fetching devices: \(error)")
+        }
     }
     
     func authorizeBluetooth() {

--- a/Sources/ReliaBLE/BluetoothActor.swift
+++ b/Sources/ReliaBLE/BluetoothActor.swift
@@ -24,7 +24,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-import Combine
 import CoreBluetooth
 import Foundation
 
@@ -50,8 +49,8 @@ private struct DiscoveryPayload: @unchecked Sendable {
 
 /// Process-wide global actor that serializes all CoreBluetooth interactions.
 ///
-/// All mutable BLE state—`CBCentralManager`, Combine subjects, and discovered
-/// peripherals—are owned exclusively by this actor. Two `ReliaBLEManager` instances
+/// All mutable BLE state—`CBCentralManager`, per-subscriber `AsyncStream` continuations, and
+/// discovered peripherals—are owned exclusively by this actor. Two `ReliaBLEManager` instances
 /// share the same isolation domain; this is acceptable because CoreBluetooth already
 /// enforces a single central manager per process.
 ///
@@ -82,40 +81,114 @@ public actor BluetoothActor {
     /// `id`; operations that need the live peripheral look it up here.
     private var cbPeripherals: [String: CBPeripheral] = [:]
 
-    // Combine subjects — written only from actor-isolated context.
-    let stateSubject = CurrentValueSubject<BluetoothState, Never>(.unknown)
-    let discoverySubject = PassthroughSubject<PeripheralDiscoveryEvent, Never>()
-    let discoveredPeripheralsSubject = PassthroughSubject<[Peripheral], Never>()
-
-    // MARK: - nonisolated(unsafe) Bridging Properties
+    // MARK: - AsyncStream Broadcaster State
     //
-    // Publishers are extracted once in `init` and never reassigned — safe for concurrent reads.
-    // `currentBluetoothState` is written only by the serial actor executor via
-    // `broadcastState(_:)` — safe for concurrent reads (value semantics, no partial writes).
-    //
-    // TODO: All removed in Step 3 when AnyPublisher is replaced by AsyncStream.
+    // One continuation per active subscriber, keyed by a per-subscription UUID. Mutated only on
+    // the actor's serial executor: the stream factories register on a `@BluetoothActor` hop, the
+    // broadcast sites iterate to `yield`, and each `onTermination` handler prunes its own entry.
 
-    /// Publisher for the real-time Bluetooth state. **TODO: removed in Step 3.**
-    nonisolated(unsafe) let statePublisher: AnyPublisher<BluetoothState, Never>
+    private var stateContinuations: [UUID: AsyncStream<BluetoothState>.Continuation] = [:]
+    private var discoveryContinuations: [UUID: AsyncStream<PeripheralDiscoveryEvent>.Continuation] = [:]
+    private var peripheralsContinuations: [UUID: AsyncStream<[Peripheral]>.Continuation] = [:]
 
-    /// Publisher for peripheral discovery events. **TODO: removed in Step 3.**
-    nonisolated(unsafe) let discoveryPublisher: AnyPublisher<PeripheralDiscoveryEvent, Never>
-
-    /// Publisher for the current list of discovered peripherals. **TODO: removed in Step 3.**
-    nonisolated(unsafe) let discoveredPeripheralsPublisher: AnyPublisher<[Peripheral], Never>
+    // MARK: - nonisolated(unsafe) Bridging Property
 
     /// Synchronous snapshot of the current Bluetooth state.
     ///
-    /// Written only from `broadcastState(_:)` on the actor's serial executor.
-    /// **TODO: removed in Step 3.**
+    /// Written only from `broadcastState(_:)` on the actor's serial executor — safe for concurrent
+    /// reads (value semantics, no partial writes). Retained as the backing store for the
+    /// synchronous `currentState` accessor and as the replay value handed to each new
+    /// `stateStream()` subscriber.
     nonisolated(unsafe) var currentBluetoothState: BluetoothState = .unknown
 
     // MARK: - Initialization
 
-    private init() {
-        statePublisher = stateSubject.eraseToAnyPublisher()
-        discoveryPublisher = discoverySubject.eraseToAnyPublisher()
-        discoveredPeripheralsPublisher = discoveredPeripheralsSubject.eraseToAnyPublisher()
+    private init() {}
+
+    // MARK: - Event Streams
+
+    /// Returns a fresh `AsyncStream` of Bluetooth state changes for a single subscriber.
+    ///
+    /// Each call mints an independent stream; multiple subscribers are supported by design. The
+    /// current state is replayed as the first element (`.bufferingNewest(1)`, latest-wins), so a
+    /// new subscriber always observes the current state without waiting for the next broadcast.
+    nonisolated func stateStream() -> AsyncStream<BluetoothState> {
+        AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            Task { await BluetoothActor.shared.register(stateContinuation: continuation) }
+        }
+    }
+
+    /// Returns a fresh `AsyncStream` of peripheral discovery events for a single subscriber.
+    ///
+    /// Unlike ``stateStream()`` and ``discoveredPeripheralsStream()`` this feed does **not** replay
+    /// a value on subscription; a subscriber only receives advertisements observed after it
+    /// registers. An advertisement that arrives in the narrow window between stream creation and
+    /// continuation registration is missed — accepted for a lightweight advertisements feed.
+    nonisolated func peripheralDiscoveriesStream() -> AsyncStream<PeripheralDiscoveryEvent> {
+        AsyncStream { continuation in
+            Task { await BluetoothActor.shared.register(discoveryContinuation: continuation) }
+        }
+    }
+
+    /// Returns a fresh `AsyncStream` of the current discovered-peripherals list for a single
+    /// subscriber.
+    ///
+    /// The current list is replayed as the first element (`.bufferingNewest(1)`, latest-wins), so
+    /// a new subscriber immediately observes the peripherals already discovered.
+    nonisolated func discoveredPeripheralsStream() -> AsyncStream<[Peripheral]> {
+        AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            Task { await BluetoothActor.shared.register(peripheralsContinuation: continuation) }
+        }
+    }
+
+    // MARK: - Continuation Registration
+    //
+    // Registration runs as a single, indivisible actor job: the replay-yield, dictionary insert,
+    // and `onTermination` assignment cannot interleave with a broadcast. The only residual gap is
+    // the window between `AsyncStream` creation and this job starting — an event emitted then is
+    // missed by a *new* (replay-less) `peripheralDiscoveries` subscriber. Accepted and documented.
+
+    private func register(stateContinuation continuation: AsyncStream<BluetoothState>.Continuation) {
+        let id = UUID()
+        continuation.yield(currentBluetoothState)
+        stateContinuations[id] = continuation
+        continuation.onTermination = { _ in
+            Task { await BluetoothActor.shared.removeStateContinuation(id) }
+        }
+    }
+
+    private func register(discoveryContinuation continuation: AsyncStream<PeripheralDiscoveryEvent>.Continuation) {
+        let id = UUID()
+        discoveryContinuations[id] = continuation
+        continuation.onTermination = { _ in
+            Task { await BluetoothActor.shared.removeDiscoveryContinuation(id) }
+        }
+    }
+
+    private func register(peripheralsContinuation continuation: AsyncStream<[Peripheral]>.Continuation) {
+        let id = UUID()
+        continuation.yield(discoveredPeripherals)
+        peripheralsContinuations[id] = continuation
+        continuation.onTermination = { _ in
+            Task { await BluetoothActor.shared.removePeripheralsContinuation(id) }
+        }
+    }
+
+    private func removeStateContinuation(_ id: UUID) { stateContinuations[id] = nil }
+    private func removeDiscoveryContinuation(_ id: UUID) { discoveryContinuations[id] = nil }
+    private func removePeripheralsContinuation(_ id: UUID) { peripheralsContinuations[id] = nil }
+
+    /// Yields a value to every registered continuation in `continuations`.
+    ///
+    /// Yielding to an already-finished continuation is a harmless no-op, so this never prunes —
+    /// dead continuations remove themselves via their `onTermination` handler.
+    private func broadcast<Element: Sendable>(
+        _ value: Element,
+        to continuations: [UUID: AsyncStream<Element>.Continuation]
+    ) {
+        for continuation in continuations.values {
+            continuation.yield(value)
+        }
     }
 
     // MARK: - Configuration
@@ -245,10 +318,10 @@ public actor BluetoothActor {
     }
 
     private func broadcastState(_ state: BluetoothState) {
-        stateSubject.send(state)
-        // nonisolated(unsafe) write — safe: written only from the actor's serial executor.
-        // TODO: removed in Step 3
+        // nonisolated(unsafe) write — safe: written only from the actor's serial executor. Also
+        // serves as the replay value handed to each new `stateStream()` subscriber.
         currentBluetoothState = state
+        broadcast(state, to: stateContinuations)
     }
 
     // MARK: - Delegate Entry Points (called by BluetoothDelegateShim)
@@ -286,8 +359,9 @@ public actor BluetoothActor {
 
         // Emit lightweight discovery feed.
         // TODO: Implement verbose log level
-        discoverySubject.send(
-            PeripheralDiscoveryEvent(cbPeripheral: cbPeripheral, advertisement: advertisement, rssi: rssi)
+        broadcast(
+            PeripheralDiscoveryEvent(cbPeripheral: cbPeripheral, advertisement: advertisement, rssi: rssi),
+            to: discoveryContinuations
         )
 
         // TODO: FR-8.5: Unique Identifier from Manufacturing Data — connect to id once implemented
@@ -339,13 +413,13 @@ public actor BluetoothActor {
 
         // Stash the live reference under the resolved id. Never escapes the actor.
         cbPeripherals[resolvedId] = cbPeripheral
-        discoveredPeripheralsSubject.send(discoveredPeripherals)
+        broadcast(discoveredPeripherals, to: peripheralsContinuations)
     }
 
     private func invalidatePeripherals() {
         // The value snapshots hold no CoreBluetooth reference to clear; drop the live registry instead.
         cbPeripherals.removeAll()
-        discoveredPeripheralsSubject.send(discoveredPeripherals)
+        broadcast(discoveredPeripherals, to: peripheralsContinuations)
         log?.debug("Invalidated all peripheral references")
     }
 
@@ -364,7 +438,7 @@ public actor BluetoothActor {
                 cbPeripherals[p.id] = cbPeripheral
             }
         }
-        discoveredPeripheralsSubject.send(discoveredPeripherals)
+        broadcast(discoveredPeripherals, to: peripheralsContinuations)
         log?.debug("Refreshed \(retrieved.count) peripherals from CBCentralManager")
     }
 

--- a/Sources/ReliaBLE/BluetoothManager.swift
+++ b/Sources/ReliaBLE/BluetoothManager.swift
@@ -24,12 +24,11 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-import Combine
 import CoreBluetooth
 import Foundation
 
 /// Internal intermediary that forwards BLE operations to ``BluetoothActor`` and exposes
-/// synchronous `AnyPublisher` properties for consumption by ``ReliaBLEManager``.
+/// synchronous `AsyncStream` properties for consumption by ``ReliaBLEManager``.
 ///
 /// This class is removed in Step 4 when `ReliaBLEManager` collapses the indirection and
 /// becomes `nonisolated Sendable`.
@@ -67,14 +66,14 @@ class BluetoothManager {
 
     // MARK: - State
 
-    /// Publisher for the real-time state of the underlying Core Bluetooth system.
-    /// Reads the `nonisolated(unsafe)` publisher on ``BluetoothActor``. TODO: removed in Step 3.
-    var state: AnyPublisher<BluetoothState, Never> {
-        BluetoothActor.shared.statePublisher
+    /// A fresh `AsyncStream` of real-time state changes of the underlying Core Bluetooth system.
+    /// Each access mints an independent stream via the ``BluetoothActor`` broadcaster.
+    var state: AsyncStream<BluetoothState> {
+        BluetoothActor.shared.stateStream()
     }
 
     /// Synchronous access to the current state of the underlying Core Bluetooth system.
-    /// Reads the `nonisolated(unsafe)` property on ``BluetoothActor``. TODO: removed in Step 3.
+    /// Reads the `nonisolated(unsafe)` snapshot on ``BluetoothActor``.
     var currentState: BluetoothState {
         BluetoothActor.shared.currentBluetoothState
     }
@@ -92,16 +91,17 @@ class BluetoothManager {
 
     // MARK: - Scanning
 
-    /// Publisher that emits peripheral discovery events during scanning. It is meant to be a
-    /// lightweight advertisements feed for cases where the integrating app needs to process
-    /// individual advertisements.
-    var peripheralDiscoveries: AnyPublisher<PeripheralDiscoveryEvent, Never> {
-        BluetoothActor.shared.discoveryPublisher
+    /// A fresh `AsyncStream` that emits peripheral discovery events during scanning. It is meant to
+    /// be a lightweight advertisements feed for cases where the integrating app needs to process
+    /// individual advertisements. This stream does not replay; subscribe before scanning.
+    var peripheralDiscoveries: AsyncStream<PeripheralDiscoveryEvent> {
+        BluetoothActor.shared.peripheralDiscoveriesStream()
     }
 
-    /// Publisher that emits the current list of discovered peripherals.
-    var discoveredPeripherals: AnyPublisher<[Peripheral], Never> {
-        BluetoothActor.shared.discoveredPeripheralsPublisher
+    /// A fresh `AsyncStream` that emits the current list of discovered peripherals, replaying the
+    /// latest list on subscription.
+    var discoveredPeripherals: AsyncStream<[Peripheral]> {
+        BluetoothActor.shared.discoveredPeripheralsStream()
     }
 
     /// Starts (or restarts) scanning for peripherals. If scanning is already in progress,

--- a/Sources/ReliaBLE/Documentation.docc/GettingStarted.md
+++ b/Sources/ReliaBLE/Documentation.docc/GettingStarted.md
@@ -52,23 +52,22 @@ iOS requires permission from the user for BLE access. To set this up in your pro
    }
    ```
 
-3. (Optional) Monitor Bluetooth state changes by subscribing to the ``ReliaBLEManager/state`` publisher:
+3. (Optional) Monitor Bluetooth state changes by iterating the ``ReliaBLEManager/state`` stream. It is an `AsyncStream`, so consume it with `for await` — typically inside a SwiftUI `.task { … }`, which cancels the loop when the view disappears:
    ```swift
-   bleManager.state
-       .sink { state in
-           switch state {
-           case .ready:
-               // Bluetooth is ready to use
-           case .unauthorized(let authStatus):
-               // Handle unauthorized state
-           case .poweredOff:
-               // Prompt user to enable Bluetooth
-           default:
-               break
-           }
+   for await state in bleManager.state {
+       switch state {
+       case .ready:
+           // Bluetooth is ready to use
+       case .unauthorized(let authStatus):
+           // Handle unauthorized state
+       case .poweredOff:
+           // Prompt user to enable Bluetooth
+       default:
+           break
        }
-       .store(in: &cancellables)
+   }
    ```
+   The current state is replayed as the stream's first element, so a new subscriber immediately observes the latest state.
 
 Note: The authorization prompt will only appear once. It is safe to call `ReliaBLEManager.authorizeBluetooth()` multiple times. If the user already granted permission it will be a no-op. If the user denies permission, they'll need to enable it manually through the Settings app.
 
@@ -117,7 +116,7 @@ if bleManager.currentState == .ready {
 }
 ```
 
-You can monitor the ``ReliaBLEManager/state`` publisher (as shown in the Authorizing Bluetooth section) to ensure Bluetooth is in the `.ready` state before calling `startScanning()`. Scanning will continue until you explicitly call `stopScanning()` or if Bluetooth becomes unavailable.
+You can monitor the ``ReliaBLEManager/state`` stream (as shown in the Authorizing Bluetooth section) to ensure Bluetooth is in the `.ready` state before calling `startScanning()`. Scanning will continue until you explicitly call `stopScanning()` or if Bluetooth becomes unavailable.
 
 ## Observing Discovered Peripherals
 
@@ -126,17 +125,16 @@ While scanning, ReliaBLE surfaces results two ways:
 - ``ReliaBLEManager/peripheralDiscoveries`` emits a lightweight ``PeripheralDiscoveryEvent`` for every advertisement received — useful when you need to process individual advertisement packets.
 - ``ReliaBLEManager/discoveredPeripherals`` emits the current de-duplicated list of ``Peripheral`` values each time it changes.
 
+Both are `AsyncStream`s. Each property access returns a *fresh, independent* stream, so multiple subscribers are supported by design — consume each with `for await`, typically inside a SwiftUI `.task { … }` (which cancels the loop automatically when the view disappears). ``ReliaBLEManager/state`` and ``ReliaBLEManager/discoveredPeripherals`` replay their latest value to every new subscriber; ``ReliaBLEManager/peripheralDiscoveries`` does **not** replay, so subscribe before you start scanning to avoid missing early advertisements.
+
 A ``Peripheral`` is an immutable, `Sendable` value snapshot: it carries the peripheral's ``Peripheral/id``, ``Peripheral/name``, ``Peripheral/rssi``, ``Peripheral/lastSeen``, and a strongly-typed ``AdvertisementData`` rather than a raw `[String: Any]` dictionary. Because it is a value type, it is safe to hand directly to your UI.
 
 ```swift
-bleManager.discoveredPeripherals
-    .receive(on: DispatchQueue.main)
-    .sink { peripherals in
-        for peripheral in peripherals {
-            print(peripheral.name ?? peripheral.id, peripheral.advertisement?.serviceUUIDs ?? [])
-        }
+for await peripherals in bleManager.discoveredPeripherals {
+    for peripheral in peripherals {
+        print(peripheral.name ?? peripheral.id, peripheral.advertisement?.serviceUUIDs ?? [])
     }
-    .store(in: &cancellables)
+}
 ```
 
 If your app already knows a peripheral's identity ahead of time — for example, a wearable bound to the user's account — you can construct a ``Peripheral`` directly with ``Peripheral/init(id:)``. Such a snapshot has no ``Peripheral/advertisement`` until ReliaBLE matches it against the corresponding device during discovery.

--- a/Sources/ReliaBLE/ReliaBLEManager.swift
+++ b/Sources/ReliaBLE/ReliaBLEManager.swift
@@ -24,7 +24,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 //  SOFTWARE.
 
-import Combine
 import CoreBluetooth
 import Foundation
 
@@ -55,8 +54,17 @@ public class ReliaBLEManager {
     
     // MARK: - State
 
-    /// Publisher for the real-time state of the underlying Core Bluetooth system.
-    public var state: AnyPublisher<BluetoothState, Never> {
+    /// A multi-subscriber `AsyncStream` of real-time state changes of the underlying Core Bluetooth
+    /// system. Each property access returns a fresh, independent stream; the current state is
+    /// replayed as the first element, so a new subscriber immediately observes the latest state.
+    ///
+    /// Consume it with `for await`:
+    /// ```swift
+    /// for await state in bleManager.state {
+    ///     // react to state
+    /// }
+    /// ```
+    public var state: AsyncStream<BluetoothState> {
         bluetoothManager.state
     }
     
@@ -75,14 +83,21 @@ public class ReliaBLEManager {
     
     // MARK: - Scanning
 
-    /// Publisher that emits peripheral discovery events during scanning. It is meant to be a lightweight
-    /// advertisements feed for cases where the integrating app needs to process individual advertisements.
-    public var peripheralDiscoveries: AnyPublisher<PeripheralDiscoveryEvent, Never> {
+    /// A multi-subscriber `AsyncStream` that emits peripheral discovery events during scanning. It
+    /// is meant to be a lightweight advertisements feed for cases where the integrating app needs to
+    /// process individual advertisements.
+    ///
+    /// Each property access returns a fresh, independent stream. Unlike ``state`` and
+    /// ``discoveredPeripherals`` this stream does **not** replay a value on subscription — subscribe
+    /// before you start scanning to avoid missing early advertisements.
+    public var peripheralDiscoveries: AsyncStream<PeripheralDiscoveryEvent> {
         bluetoothManager.peripheralDiscoveries
     }
-    
-    /// Publisher that emits the current list of discovered peripherals.
-    public var discoveredPeripherals: AnyPublisher<[Peripheral], Never> {
+
+    /// A multi-subscriber `AsyncStream` that emits the current de-duplicated list of discovered
+    /// peripherals each time it changes. Each property access returns a fresh, independent stream;
+    /// the current list is replayed as the first element on subscription.
+    public var discoveredPeripherals: AsyncStream<[Peripheral]> {
         bluetoothManager.discoveredPeripherals
     }
     

--- a/Tests/ReliaBLETests/ReliaBLEManagerTests.swift
+++ b/Tests/ReliaBLETests/ReliaBLEManagerTests.swift
@@ -56,3 +56,74 @@ import Testing
         #expect(false, "Expected PeripheralError.notFound, got \(error)")
     }
 }
+
+// MARK: - Event Stream Broadcaster
+
+@Test func stateStreamReplaysToConcurrentSubscribers() async throws {
+    let manager = ReliaBLEManager()
+
+    // Two independent streams from two separate property accesses.
+    var subscriberA = manager.state.makeAsyncIterator()
+    var subscriberB = manager.state.makeAsyncIterator()
+
+    // Each subscriber replays the current state as its first element. A shared single stream
+    // could not replay to both, so independent replay proves each access mints a distinct stream.
+    let replayA = await subscriberA.next()
+    let replayB = await subscriberB.next()
+
+    #expect(replayA != nil)
+    #expect(replayB != nil)
+}
+
+@Test func stateBroadcastReachesAllSubscribers() async throws {
+    let manager = ReliaBLEManager()
+
+    var subscriberA = manager.state.makeAsyncIterator()
+    var subscriberB = manager.state.makeAsyncIterator()
+
+    // Drain the replayed element. Awaiting it also guarantees both continuations are registered
+    // (the replay is yielded during registration), so the broadcast below cannot be missed.
+    _ = await subscriberA.next()
+    _ = await subscriberB.next()
+
+    // Force a state broadcast through the real actor path; both live subscribers receive it.
+    await BluetoothActor.shared.updateState()
+
+    let broadcastA = await subscriberA.next()
+    let broadcastB = await subscriberB.next()
+
+    #expect(broadcastA != nil)
+    #expect(broadcastB != nil)
+}
+
+@Test func peripheralDiscoveriesDoesNotReplay() async throws {
+    let manager = ReliaBLEManager()
+
+    // No scanning has occurred and the discoveries feed does not replay, so no event should
+    // arrive within a short grace period.
+    let event = await firstEvent(from: manager.peripheralDiscoveries, withinNanoseconds: 200_000_000)
+
+    #expect(event == nil)
+}
+
+/// Returns the first event from `stream`, or `nil` if none arrives within `nanoseconds`.
+private func firstEvent(
+    from stream: AsyncStream<PeripheralDiscoveryEvent>,
+    withinNanoseconds nanoseconds: UInt64
+) async -> PeripheralDiscoveryEvent? {
+    await withTaskGroup(of: PeripheralDiscoveryEvent?.self) { group in
+        group.addTask {
+            for await event in stream {
+                return event
+            }
+            return nil
+        }
+        group.addTask {
+            try? await Task.sleep(nanoseconds: nanoseconds)
+            return nil
+        }
+        let first = await group.next() ?? nil
+        group.cancelAll()
+        return first
+    }
+}

--- a/docs/plans/combine-to-asyncstream-2026-06-18.md
+++ b/docs/plans/combine-to-asyncstream-2026-06-18.md
@@ -1,0 +1,118 @@
+# Combine → AsyncStream Broadcaster: Plan (Step 3 of 5)
+*Issue #12 · 2026-06-18*
+
+## Goal
+
+Replace the three `AnyPublisher` event surfaces on `ReliaBLEManager` — `state`, `peripheralDiscoveries`, `discoveredPeripherals` — with per-subscription `AsyncStream`s fed by an in-`BluetoothActor` broadcaster, and remove `Combine` from `Sources/ReliaBLE` and `Sources/ReliaBLEMock` entirely. Update the Demo's `CentralViewModel` to consume via `.task { for await … }`. Fixes **Cluster 2** of the Swift 6 concurrency audit (non-`Sendable` Combine types in the public API).
+
+This is **Step 3 of 5**. Steps 1 (#13, `@globalActor BluetoothActor`) and 2 (#17, `Peripheral` Sendable struct) are merged. Step 4 (#18) makes `ReliaBLEManager` `Sendable` and collapses `BluetoothManager`; Step 5 is logging/strict-concurrency/DocC polish.
+
+## Background
+
+All current state verified at the file:line refs below.
+
+**Public surface (`ReliaBLEManager.swift`)** — three computed properties forward to `BluetoothManager`:
+- `state: AnyPublisher<BluetoothState, Never>` (:55)
+- `peripheralDiscoveries: AnyPublisher<PeripheralDiscoveryEvent, Never>` (:80)
+- `discoveredPeripherals: AnyPublisher<[Peripheral], Never>` (:85)
+- `currentState: BluetoothState` (:60) — **synchronous** accessor, *not* a Combine surface (see Open Questions).
+- `import Combine` (:27).
+
+**Forwarding layer (`BluetoothManager.swift`)** — thin computed getters onto the actor's bridging props:
+- `state` → `BluetoothActor.shared.statePublisher` (:72)
+- `currentState` → `BluetoothActor.shared.currentBluetoothState` (:79)
+- `peripheralDiscoveries` → `discoveryPublisher` (:98), `discoveredPeripherals` → `discoveredPeripheralsPublisher` (:103)
+- `import Combine` (:27). `BluetoothState: Sendable` enum (:147).
+
+**Actor internals (`BluetoothActor.swift`)** — all Combine state is actor-owned, bridged out via `nonisolated(unsafe)`:
+- Subjects (:83–85): `stateSubject = CurrentValueSubject(.unknown)`, `discoverySubject = PassthroughSubject`, `discoveredPeripheralsSubject = PassthroughSubject`.
+- `nonisolated(unsafe) let` publishers (:96, :99, :102) + `nonisolated(unsafe) var currentBluetoothState = .unknown` (:108).
+- `init()` erases subjects → publishers (:113–115).
+- `.send(...)` sites: `broadcastState` (:244, also writes `currentBluetoothState` :248), `handlePeripheralDiscovered` (discovery event :287; list :336), `invalidatePeripherals` (:341), `refreshPeripherals` (:359).
+- `import Combine` (:27).
+- The actor already holds `discoveredPeripherals: [Peripheral]` (the list-replay source) and `cbPeripherals` registry — both stay.
+
+**Cleanup markers** — 7 `// TODO: removed in Step 3` sites: `BluetoothActor.swift` (:95, :98, :101, :107, :247) and `BluetoothManager.swift` (:71, :77).
+
+**Element types are already `Sendable`** (Step 2): `Peripheral` (struct), `PeripheralDiscoveryEvent` (struct), `BluetoothState` (enum). No element-type work needed.
+
+**Stays in place (do NOT remove):** `SendableWrapper<T>: @unchecked Sendable` (`BluetoothActor.swift:30`) — it hops the non-`Sendable` `CBPeripheral` + `[String: Any]` from the delegate queue into the actor. It is **not** a Combine workaround (no Step-3 TODO marker) and was deliberately retained in Step 2.
+
+**Demo consumption (`Demo/ReliaBLE Demo/.../Central/`)** — single consumer, `CentralViewModel.setupSubscriptions()`:
+- `@Observable class CentralViewModel` (CentralViewModel.swift:38) — not `@MainActor`, not `ObservableObject`. `var cancellables = Set<AnyCancellable>()` (:42), `var currentState` (:39).
+- `state` → `.receive(on: .main).assign(to: \.currentState)` (:53–57).
+- `peripheralDiscoveries` → `.sink { insert DiscoveryEvent into SwiftData }` (:59–68).
+- `discoveredPeripherals` → `.sink { sync Device SwiftData models }` (:70–89).
+- `import Combine` at CentralViewModel.swift:27 and CentralView.swift:27.
+- Wiring: `.onAppear { setDependencies(...) }` → `setupSubscriptions()` (CentralView.swift:142); teardown `.onDisappear { cancellables.removeAll() }` (:144).
+
+**Tests** — `Tests/ReliaBLETests/ReliaBLEManagerTests.swift` has **zero** references to Combine or the three surfaces; the migration breaks no existing test.
+
+## Approach
+
+The broadcaster lives entirely inside `BluetoothActor`. Three `[UUID: AsyncStream<T>.Continuation]` dictionaries replace the three Combine subjects; three `nonisolated` factory methods mint a fresh stream per call; the existing broadcast paths `.yield(...)` into the continuations instead of `subject.send(...)`.
+
+**Broadcaster state** (replaces the subjects + erased publishers):
+```swift
+private var stateContinuations: [UUID: AsyncStream<BluetoothState>.Continuation] = [:]
+private var discoveryContinuations: [UUID: AsyncStream<PeripheralDiscoveryEvent>.Continuation] = [:]
+private var peripheralsContinuations: [UUID: AsyncStream<[Peripheral]>.Continuation] = [:]
+// kept: nonisolated(unsafe) var currentBluetoothState — replay source + sync `currentState` backing
+```
+
+**Stream factories** (internal `nonisolated`, called by the façade):
+```swift
+nonisolated func stateStream() -> AsyncStream<BluetoothState> {
+    AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+        let id = UUID()
+        Task { @BluetoothActor in
+            continuation.yield(currentBluetoothState)        // replay (state only)
+            stateContinuations[id] = continuation
+            continuation.onTermination = { _ in
+                Task { @BluetoothActor in stateContinuations[id] = nil }
+            }
+        }
+    }
+}
+```
+`discoveredPeripheralsStream()` is identical but replays the current `discoveredPeripherals` array (also `.bufferingNewest(1)`). `peripheralDiscoveriesStream()` omits the replay yield and uses the default unbounded buffer (BLE ad rate is low; switch to `.bufferingNewest(n)` only if back-pressure is ever observed).
+
+**Atomicity / ordering:** the factory's `Task { @BluetoothActor in … }` body has no `await`, so the replay-yield, registration, and `onTermination` assignment run as one indivisible actor job — they cannot interleave with `broadcastState`. The only residual gap is the window between `AsyncStream` creation and that job starting: an event emitted then is missed by a *new* `peripheralDiscoveries` subscriber (no replay). Accepted for a lightweight advertisements feed; documented, not engineered around.
+
+**Broadcast sites** (5 `.send` → yields): `broadcastState` loops `stateContinuations` (and still writes `currentBluetoothState`); `handlePeripheralDiscovered` yields the event to `discoveryContinuations` and the updated array to `peripheralsContinuations`; `invalidatePeripherals` / `refreshPeripherals` yield the array to `peripheralsContinuations`. A small private `broadcast(_:to:)` helper keeps the loops DRY — it just iterates `.values` and yields; it never prunes. Dead continuations are removed by their own `onTermination` (a fire-and-forget actor hop, which is safe because yielding to an already-finished continuation is a harmless no-op).
+
+**Façade:** `BluetoothManager` and `ReliaBLEManager` swap each `AnyPublisher<X, Never>` property for `AsyncStream<X>`, delegating to the actor factory (`BluetoothActor.shared.stateStream()`, etc.). `currentState` and its `nonisolated(unsafe)` snapshot are untouched. `import Combine` leaves all three files.
+
+**Demo:** `CentralView` replaces the `.onAppear`-installs-sinks / `.onDisappear`-clears-cancellables pattern with three `.task { for await v in reliaBLE.<surface> { … } }` blocks (SwiftUI cancels them on disappear). Each loop body hops to the main actor (`await MainActor.run { … }` or an `@MainActor` VM handler) before touching `@Observable` state or SwiftData. `CentralViewModel` drops `import Combine`, `cancellables`, and `setupSubscriptions()`, keeping the conversion logic in handler methods.
+
+## Work Items
+
+Edit the library inside-out so the build stays green; the three library files (1–3) must land together if any intermediate build is required.
+
+1. **`BluetoothActor.swift` — broadcaster core.** Drop `import Combine`, the three subjects (:83–85), the three `nonisolated(unsafe) let …Publisher` (:96–102), and the `init` erasure (:113–115). Add the three continuation dictionaries + three `nonisolated` stream factories. Rewrite the 5 yield sites (`broadcastState` :244, `handlePeripheralDiscovered` :287/:336, `invalidatePeripherals` :341, `refreshPeripherals` :359). **Keep** `currentBluetoothState` (reword its TODO :107 → “retained for sync `currentState` + `stateStream()` replay”), `SendableWrapper` (:30), `forceMock`, and lazy-init.
+2. **`BluetoothManager.swift` — façade.** Drop `import Combine`; retype `state` / `peripheralDiscoveries` / `discoveredPeripherals` (:72/:98/:103) to `AsyncStream<…>` delegating to the actor factories; reword/remove the Step-3 TODOs (:71, :77). Leave `currentState` (:79) and the `BluetoothState` enum (:147) unchanged.
+3. **`ReliaBLEManager.swift` — public surface.** Drop `import Combine` (:27); retype the three properties (:55/:80/:85) to `AsyncStream<…>`; refresh the doc comments (s/Publisher/stream). Leave `currentState` (:60) unchanged. *(Breaking API change — intentional, pre-1.0.)*
+4. **Demo — `CentralViewModel.swift` + `CentralView.swift`.** Remove `import Combine`, `cancellables`, and `setupSubscriptions()`; move the existing SwiftData/assignment logic into `@MainActor` handler methods (`updateState`, `insertDiscovery`, `syncDevices`). In `CentralView`, replace the onAppear/onDisappear wiring with three `.task` loops feeding those handlers; keep `setDependencies` for context/manager injection.
+5. **Tests — `ReliaBLEManagerTests.swift`.** Existing tests are unaffected (they touch none of the surfaces). Add one test (via `ReliaBLEMock`): two concurrent `stateStream()` subscribers both replay the current state and receive a later broadcast; `peripheralDiscoveriesStream()` does not replay; each property access returns a distinct stream.
+6. **DocC — `Documentation.docc/GettingStarted.md` (+ `Documentation.md`).** Replace the `.sink` / `.store(in:)` examples with `.task { for await … }`. Document prominently: fresh stream per access, multi-subscriber by design, replay for `state` / `discoveredPeripherals`, no replay for `peripheralDiscoveries`.
+7. **Verify.** `swift build` + `swift test`; grep confirms zero `import Combine` in `Sources/ReliaBLE*`; Demo scheme builds; `currentState` still synchronous; `forceMock` / lazy-init / `SendableWrapper` intact.
+
+## Decisions (resolved at planning)
+
+1. **`currentState` stays synchronous; `currentBluetoothState` stays `nonisolated(unsafe)`.** It is not a Combine surface. Step 3 removes only Combine machinery; the snapshot now backs both `currentState` and `stateStream()` replay. Its TODO is reworded, not actioned. Revisiting `currentState`'s isolation belongs to Step 4 (#18).
+2. **Buffering:** `.bufferingNewest(1)` for the two replay/snapshot surfaces — exactly 1, latest-wins; a larger buffer would hand a slow consumer stale intermediate snapshots. Unbounded (default) for the discoveries feed.
+3. **No typed wrapper.** Return plain `AsyncStream<T>`; defer a `BluetoothEventStream<T>` façade unless an ergonomic need appears (the issue's open question).
+4. **`peripheralDiscoveries` registration window** (an event lost between stream creation and continuation registration) is accepted and documented, not engineered around.
+
+## Open Questions
+
+None blocking. Two items to confirm during implementation:
+- Whether a subscriber that opens `stateStream()` exactly as `broadcastState` fires sees a duplicated value — `.bufferingNewest(1)` collapses this to the latest, so it is benign; assert in the multi-subscriber test.
+- Demo only: keep `setDependencies` vs. fold manager/context capture directly into the `.task` blocks — cosmetic, decide in code.
+
+## References
+
+- Issue #12 (this); parent #10; depends on #13 (Step 1, merged) and #17 (Step 2, merged).
+- Investigation report: `docs/investigations/swift6-concurrency-audit-2026-05-13.md` — Findings §1/§2, Cluster 2, Recommendations §A (AsyncStream broadcaster).
+- Step 1 plan: `docs/plans/bluetooth-actor-migration-2026-06-08.md`; Step 2 plan: `docs/plans/peripheral-sendable-struct-2026-06-13.md`.
+- Key files: `Sources/ReliaBLE/BluetoothActor.swift`, `BluetoothManager.swift`, `ReliaBLEManager.swift`; `Sources/ReliaBLE/Documentation.docc/`; `Demo/ReliaBLE Demo/ReliaBLE Demo/Central/CentralViewModel.swift`.

--- a/docs/reviews/combine-to-asyncstream-plan-critique-2026-06-18.md
+++ b/docs/reviews/combine-to-asyncstream-plan-critique-2026-06-18.md
@@ -1,0 +1,26 @@
+# Critique: Combine → AsyncStream Plan (2026-06-18)
+
+**Scope**: Only the three named seams in `BluetoothActor.swift`, `BluetoothManager.swift`, `ReliaBLEManager.swift` (plan lines 83-108, 244, 287, 336, 341, 359).
+
+## 1. Top 3 Under-specified Seams
+
+- `stateStream()` replay of `currentBluetoothState` (plan:59) — no specification of what happens if `currentBluetoothState` is mutated between the `yield` and the first downstream `for await` consumption.
+- `peripheralDiscoveriesStream()` registration window (plan:68) — the documented “event lost” gap is accepted but has no test or logging hook to surface it in production.
+- `broadcast(_:to:)` helper (plan:78) — signature, error handling, and whether it removes dead continuations are unspecified.
+
+## 2. Contradictions / Missing Dependencies
+
+- Plan says “Drop `import Combine`” from all three files (Work Items 1-3), yet `BluetoothActor.swift:30` retains `SendableWrapper<T>` which is **not** a Combine type; the TODO markers at :95/:98/:101/:107 are the only Combine-specific lines. Removing the import is safe, but the plan’s wording implies more Combine removal than actually exists.
+- `currentBluetoothState` TODO reword (plan:107) is listed under “keep” but the Work Items still say “reword its TODO” — a minor internal inconsistency.
+
+## 3. Risk of Over-planning
+
+- Work Item 5 (new multi-subscriber test) and Work Item 6 (DocC) are full implementation tasks, not plan-level decisions. They can be cut or deferred without changing the broadcaster design.
+- The “Open Questions” section is empty; the two cosmetic Demo items do not affect library order.
+
+## 4. Questions That Change Implementation Order
+
+- Must the `onTermination` cleanup `Task` be fire-and-forget, or should it be awaited inside a detached task to guarantee removal before the next broadcast?
+- Is `.bufferingNewest(1)` for `state`/`discoveredPeripherals` streams required to be exactly 1, or can it be a larger bounded buffer without affecting the “latest value” replay contract?
+
+**Broadcaster actor-isolation sanity check**: The `Task { @BluetoothActor in … }` body contains only synchronous operations (`yield`, dictionary write, `onTermination` setter). No suspension points exist inside the closure, so the three statements execute as one indivisible actor job. The documented window between `AsyncStream` creation and job start remains the only gap; `.bufferingNewest(1)` + `nonisolated(unsafe) currentBluetoothState` correctly backs both replay and the synchronous `currentState` accessor. No contradictions found in the named seams.


### PR DESCRIPTION
Plan: docs/plans/combine-to-asyncstream-2026-06-18.md
Plan Critique: docs/reviews/combine-to-asyncstream-plan-critique-2026-06-18.md

Replace the three AnyPublisher surfaces on ReliaBLEManager (state,
peripheralDiscoveries, discoveredPeripherals) with per-subscription
AsyncStreams fed by an in-BluetoothActor broadcaster, and remove Combine
from Sources/ReliaBLE and the Demo.

- BluetoothActor: three [UUID: AsyncStream.Continuation] dictionaries replace
  the Combine subjects/publishers; nonisolated stream factories mint a fresh
  stream per call and register on an actor hop. state/discoveredPeripherals
  replay their latest value (.bufferingNewest(1)); peripheralDiscoveries does
  not replay (unbounded). currentBluetoothState retained as the sync
  currentState backing + state replay source.
- BluetoothManager/ReliaBLEManager: retype the three properties to AsyncStream.
- Demo: consume via .task { for await } loops feeding @MainActor handlers;
  drop cancellables/setupSubscriptions.
- Tests: add broadcaster coverage (multi-subscriber replay, fan-out, no-replay).
- DocC: replace .sink examples with for await; document streaming semantics.

Closes #12 