### PR TITLE
Added Swift 6 strict concurrency checking (Step 5 of 5, #10)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,8 @@ let package = Package(
     targets: [
         .target(
             name: "ReliaBLE",
-            dependencies: ["Willow"]
+            dependencies: ["Willow"],
+            swiftSettings: [.swiftLanguageMode(.v6), .enableExperimentalFeature("StrictConcurrency")]
         ),
         .target(
             name: "ReliaBLEMock",
@@ -29,11 +30,13 @@ let package = Package(
                 "Willow",
                 .product(name: "CoreBluetoothMock", package: "IOS-CoreBluetooth-Mock")
             ],
-            exclude: ["ReliaBLE/CBCentralManagerFactory.swift", "ReliaBLE/Documentation.docc"]
+            exclude: ["ReliaBLE/CBCentralManagerFactory.swift", "ReliaBLE/Documentation.docc"],
+            swiftSettings: [.swiftLanguageMode(.v6), .enableExperimentalFeature("StrictConcurrency")]
         ),
         .testTarget(
             name: "ReliaBLETests",
-            dependencies: ["ReliaBLEMock"]
+            dependencies: ["ReliaBLEMock"],
+            swiftSettings: [.swiftLanguageMode(.v6), .enableExperimentalFeature("StrictConcurrency")]
         ),
     ]
 )

--- a/Sources/ReliaBLE/Documentation.docc/Documentation.md
+++ b/Sources/ReliaBLE/Documentation.docc/Documentation.md
@@ -20,9 +20,10 @@ This is a temporary overview.
 - ``PeripheralDiscoveryEvent``
 - ``PeripheralError``
 
-### Concurrency
+### Concurrency & Isolation
 
-- ``ReliaBLEManager`` — a `nonisolated`, `Sendable` façade; all Core Bluetooth state is serialized internally
+- <doc:Concurrency>
+- ``ReliaBLEManager``
 
 ### Advanced Usage
 

--- a/Sources/ReliaBLE/Documentation.docc/Topics/Concurrency.md
+++ b/Sources/ReliaBLE/Documentation.docc/Topics/Concurrency.md
@@ -1,0 +1,83 @@
+# Concurrency
+
+How ReliaBLE isolates Bluetooth state and how to safely call it from your app.
+
+## Overview
+
+ReliaBLE is built with the Swift 6 language mode and complete strict concurrency
+checking. Its public surface is designed so you can call it from anywhere — a
+SwiftUI view on the `@MainActor`, a background actor, or a detached `Task` —
+without manual locking or forced actor hops.
+
+### The isolation contract
+
+``ReliaBLEManager`` is a `nonisolated`, `Sendable` `final class`. It owns no
+mutable state itself; instead it forwards every operation to an internal
+`@globalActor` (`BluetoothActor`) that serializes all Core Bluetooth
+interactions. Because the manager is `Sendable` and nonisolated, you can hold a
+single instance and share it freely across isolation domains — there is no
+implicit `@MainActor` requirement and no forced main-thread hop.
+
+```
+ReliaBLEManager (nonisolated, Sendable)
+        │  forwards async calls
+        ▼
+BluetoothActor (@globalActor, internal)
+        │  serializes all access
+        ▼
+CBCentralManager delegate shim
+        │
+        ▼
+CoreBluetooth
+```
+
+`BluetoothActor` is an **internal** implementation detail. Consumers must not
+reference it; interact only through ``ReliaBLEManager``.
+
+### Calling actions
+
+All mutating actions are `async` and hop onto the Bluetooth actor for you:
+
+- ``ReliaBLEManager/authorizeBluetooth()``
+- ``ReliaBLEManager/startScanning(services:)``
+- ``ReliaBLEManager/stopScanning()``
+- ``ReliaBLEManager/connect(to:)``
+
+The current Bluetooth state is exposed as an `async` getter,
+``ReliaBLEManager/currentState``:
+
+```swift
+let state = await manager.currentState
+```
+
+### Observing events
+
+ReliaBLE exposes three event surfaces, each of which returns a **fresh,
+per-subscriber** `AsyncStream`. Iterate them with `for await`, ideally from a
+SwiftUI `.task` so iteration is tied to the view's lifetime:
+
+```swift
+.task {
+    for await state in manager.state {
+        self.state = state
+    }
+}
+```
+
+Replay semantics differ per stream:
+
+- ``ReliaBLEManager/state`` — replays the **latest** value to new subscribers
+  (`.bufferingNewest(1)`).
+- ``ReliaBLEManager/discoveredPeripherals`` — replays the **latest** value to new
+  subscribers (`.bufferingNewest(1)`).
+- ``ReliaBLEManager/peripheralDiscoveries`` — does **not** replay; a new
+  subscriber only receives discoveries that occur after it begins iterating.
+
+Because each call returns an independent stream, multiple parts of your app can
+observe the same surface concurrently without interfering with one another.
+
+### Value types
+
+The model types you receive — ``Peripheral``, ``AdvertisementData``, and
+``PeripheralDiscoveryEvent`` — are `Sendable` value structs, so they cross
+isolation boundaries freely.

--- a/Sources/ReliaBLE/Logging/LogWriters.swift
+++ b/Sources/ReliaBLE/Logging/LogWriters.swift
@@ -45,6 +45,11 @@ public typealias ConsoleWriter = Willow.ConsoleWriter
 
 /// The OSLogWriter class runs all modifiers in the order they were created and passes the resulting message
 /// off to an OSLog with the specified subsystem and category.
+///
+/// Sendable is synthesized for this `final class` from immutable `let` stored properties of Sendable types
+/// (`String`, `[LogModifier]`, `OSLog`). No explicit conformance is required under Swift 6 strict concurrency.
+/// If a future Willow or SDK change breaks synthesis, fall back to `: LogModifierWriter, @unchecked Sendable`
+/// (matching upstream `Willow.OSLogWriter`). Do not apply `@unchecked` unless a build actually fails.
 public final class OSLogWriter: LogModifierWriter {
     public let subsystem: String
     public let category: String

--- a/Sources/ReliaBLE/ReliaBLEConfig.swift
+++ b/Sources/ReliaBLE/ReliaBLEConfig.swift
@@ -32,7 +32,7 @@ public typealias LogLevel = Willow.LogLevel
 
 /// The `ReliaBLEConfig` struct defines the configuration options for the ReliaBLE library. This struct is used to
 /// configure the logging service used by ReliaBLE.
-public struct ReliaBLEConfig {
+public struct ReliaBLEConfig: Sendable {
     /// The log levels to that will be send to ``logWriters`` for logging. The default value is all log levels.
     public var logLevels = LogLevel.all
 

--- a/docs/plans/strict-concurrency-flag-flip-2026-06-27.md
+++ b/docs/plans/strict-concurrency-flag-flip-2026-06-27.md
@@ -1,0 +1,92 @@
+# Logging polish + strict-concurrency flag flip + DocC update: Plan (Step 5 of 5)
+*Issue #19 · 2026-06-27*
+
+## Goal
+
+Final polish pass closing out the Swift 6 migration: make `ReliaBLEConfig` explicitly `Sendable`, pin **Swift 6 language mode + complete strict concurrency** in `Package.swift` for both library targets, and add a DocC `Concurrency.md` page documenting the isolation contract. Steps 1–4 already delivered the architecture; this step makes the guarantees explicit and durable.
+
+## Background (verified current state)
+
+**Build status — already clean today.** `swift build` succeeds with no warnings in our sources. swift-tools-version is `6.1`, which defaults both targets to the **Swift 6 language mode** (= complete strict concurrency) even though `Package.swift` sets no `swiftSettings`. So the code already compiles under the regime this step makes explicit — the flag flip **pins intent**, it does not unlock new diagnostics. (A forced `-Xswiftc -strict-concurrency=complete` build also reports clean.)
+
+**Logging layer (deliverables #1–#2) — both essentially no-ops, verified:**
+- `ReliaBLEConfig` (`ReliaBLEConfig.swift:20`) is a struct with **no explicit `Sendable`**. All four stored fields are Sendable: `logLevels: LogLevel` (Willow `LogLevel: Sendable`, `LogLevel.swift:30`), `logWriters: [LogWriter]` (Willow `public protocol LogWriter: Sendable`, `LogWriter.swift:31`, so the existential array is Sendable), `logQueue: DispatchQueue` (Sendable), `loggingEnabled: Bool`. ⇒ Adding `: Sendable` compiles with **no other change**.
+- `OSLogWriter` (`LogWriters.swift:35`) is `public final class OSLogWriter: LogModifierWriter` with **no explicit Sendable**. Since `LogModifierWriter: LogWriter: Sendable`, the clean v6 build **proves OSLogWriter already satisfies Sendable implicitly**. No `@unchecked Sendable` is needed today — it is only a contingency for a future SDK where the inferred conformance breaks.
+- `LoggingService` is already `public final class … : Sendable` (`LoggingService.swift:20`). The `enabled` last-write race is deliberately left as-is (issue decision; tracked upstream as Willow#3) — no DocC note.
+
+**Public concurrency surface (delivered Steps 1–4 — informs DocC + tests):**
+- `ReliaBLEManager` is `public final class ReliaBLEManager: Sendable`, nonisolated, forwarding to the internal `@globalActor BluetoothActor.shared` (`ReliaBLEManager.swift:64`). Actions are `async` (`authorizeBluetooth()`, `startScanning(services:)`, `stopScanning()`, `connect(to:)`); `currentState` is `get async`.
+- Three event surfaces — `state`, `peripheralDiscoveries`, `discoveredPeripherals` — each return a **fresh per-subscriber** `AsyncStream`. Replay via `.bufferingNewest(1)` for `state` and `discoveredPeripherals`; `peripheralDiscoveries` does **not** replay.
+- `BluetoothActor` is **internal**. `Peripheral`, `AdvertisementData`, `PeripheralDiscoveryEvent` are `Sendable` value structs.
+
+**Tests (deliverables #6–#7) — already exist:**
+- `ReliaBLEManagerTests.swift:30` `reliaBLEManagerIsSendable` — captures a `ReliaBLEManager` in `Task.detached` and exercises every public member (streams, `currentState`, `authorizeBluetooth`, scanning, `connect`).
+- `ReliaBLEManagerTests.swift:51` `peripheralIsSendable` — captures `Peripheral` in `Task.detached`.
+- ⇒ No new tests needed; this step **verifies** they still pass under the explicit flags.
+
+**DocC catalog** (`Sources/ReliaBLE/Documentation.docc/`, excluded from `ReliaBLEMock`):
+- `Documentation.md:1-29` already has a `### Concurrency` topic group with a one-line `ReliaBLEManager` entry but **no dedicated article**. Articles live under `Topics/` (e.g. `Topics/Logging.md`) and are linked via `<doc:Name>`.
+
+## Approach
+
+The substantive work is small and low-risk because the code already compiles under Swift 6 mode. Three concrete edits plus documentation:
+
+1. One-line `Sendable` on `ReliaBLEConfig` — proven safe by the field audit above.
+2. Pin language mode + strict concurrency in `Package.swift` on **both** `ReliaBLE` and `ReliaBLEMock`, making the guarantee independent of the tools-version default. `.swiftLanguageMode(.v6)` already implies complete strict concurrency; `.enableExperimentalFeature("StrictConcurrency")` is belt-and-suspenders and harmless.
+3. Leave `OSLogWriter` as-is (conformance already satisfied); add only a short comment recording why, with the `@unchecked Sendable` fallback noted as a contingency — do **not** apply it unless a build actually fails.
+4. New DocC `Concurrency.md` article documenting the isolation contract, linked from `Documentation.md`. Optional ASCII isolation graph inline (no binary asset to manage).
+
+Verification gates the step: `swift build`, `swift test`, and `swift package generate-documentation` must all be clean.
+
+Demo cross-actor validation (audit "Preventive Measures") is **outside this step's acceptance criteria** — Issue #19 scopes acceptance to the library. If wanted, delegate it separately to a sub-agent that reads `Demo/CLAUDE.md` first.
+
+## Work Items
+
+Ordered so the build stays green at each step.
+
+1. **`ReliaBLEConfig: Sendable`.** `ReliaBLEConfig.swift:20` — change `public struct ReliaBLEConfig {` → `public struct ReliaBLEConfig: Sendable {`. No other change. *(Build green.)*
+
+2. **Pin flags in `Package.swift`.** Add an identical `swiftSettings:` to both targets. `swiftSettings:` is a sibling argument to `dependencies:` (and, for the mock, `exclude:`) in the target literal — append it last, comma-separated:
+   ```swift
+   .target(
+       name: "ReliaBLE",
+       dependencies: ["Willow"],
+       swiftSettings: [.swiftLanguageMode(.v6), .enableExperimentalFeature("StrictConcurrency")]
+   ),
+   .target(
+       name: "ReliaBLEMock",
+       dependencies: [ "Willow", .product(name: "CoreBluetoothMock", package: "IOS-CoreBluetooth-Mock") ],
+       exclude: ["ReliaBLE/CBCentralManagerFactory.swift", "ReliaBLE/Documentation.docc"],
+       swiftSettings: [.swiftLanguageMode(.v6), .enableExperimentalFeature("StrictConcurrency")]
+   ),
+   ```
+   Leave the `ReliaBLETests` target as-is. If strict checking surfaces issues from the `CBM*` aliases, the fix belongs in `CoreBluetoothMockAliases.swift` (escape hatches like `@preconcurrency`/`@retroactive @unchecked Sendable` are permitted in `ReliaBLEMock` only). Not expected — v6 is already the effective default and the target builds clean. *(Build green.)*
+
+3. **`OSLogWriter` comment.** `LogWriters.swift:35` — keep the declaration unchanged. Add a one-line comment noting Sendable is satisfied via `LogModifierWriter: LogWriter: Sendable`, with the `@unchecked Sendable` fallback recorded as a contingency (matching upstream `Willow.OSLogWriter`). Apply `@unchecked` only if a build genuinely fails. *(Build green.)*
+
+4. **DocC `Concurrency.md`.** Create `Sources/ReliaBLE/Documentation.docc/Topics/Concurrency.md`. DocC auto-compiles every `.md` in the catalog, so no manifest/index entry is required — the curation link in Work Item 5 is what surfaces it in navigation. Document:
+   - `ReliaBLEManager` is `Sendable` + nonisolated → callable from `@MainActor` SwiftUI **and** background actors with no forced MainActor hop.
+   - All actions are `async`; `currentState` is `get async`.
+   - Event surfaces return **fresh per-subscriber** `AsyncStream`s; show the SwiftUI `.task { for await … }` pattern; note replay semantics (`state`/`discoveredPeripherals` replay latest; `peripheralDiscoveries` does not).
+   - `BluetoothActor` is internal — consumers must not reference it.
+   - *(Optional)* inline ASCII isolation graph: `ReliaBLEManager (nonisolated, Sendable) → BluetoothActor (@globalActor) → delegate shim → CoreBluetooth`.
+
+5. **Link the article.** `Documentation.md:24-26` — the `### Concurrency` group currently holds a single bullet (the `ReliaBLEManager` symbol entry). Add `- <doc:Concurrency>` as a sibling bullet in that same group, keeping the symbol entry. (A `### Concurrency` heading with two bullets is valid DocC curation.)
+
+6. **Verify.**
+   - `swift build` clean on both targets.
+   - `swift test` green — confirm `reliaBLEManagerIsSendable` (:30) and `peripheralIsSendable` (:51) pass and still cover the full public surface (async `currentState`, `connect`, all three streams).
+   - `swift package generate-documentation --target ReliaBLE` (catalog lives only in the production target) builds **clean**; `Concurrency.md` renders in navigation under the Concurrency group.
+
+## Open Questions
+
+- **Demo validation in scope?** The audit lists Demo cross-actor validation under Preventive Measures, but Issue #19's acceptance criteria are library-only. Default: out of scope here — delegate separately (sub-agent reads `Demo/CLAUDE.md` first) if wanted.
+
+## References
+
+- Issue #19 (Step 5 of 5); parent #10. Depends on #13 / #17 / #12 / #18 — Steps 1–4, merged.
+- Audit: `docs/investigations/swift6-concurrency-audit-2026-05-13.md` (Recommendations §C, Migration order Step 5, Preventive Measures).
+- Upstream `enabled` race: itsniper/Willow#3 (no ReliaBLE-side work).
+- Willow Sendable constraints: `.build/checkouts/Willow/Source/LogWriter.swift:31`, `LogLevel.swift:30`.
+- Prior step plans: `docs/plans/bluetooth-actor-migration-2026-06-08.md`, `peripheral-sendable-struct-2026-06-13.md`, `combine-to-asyncstream-2026-06-18.md`, `manager-sendable-collapse-2026-06-23.md`.
+- Key files: `Sources/ReliaBLE/ReliaBLEConfig.swift:20`, `Logging/LogWriters.swift:35`, `Package.swift`, `Documentation.docc/Documentation.md`, `Tests/ReliaBLETests/ReliaBLEManagerTests.swift:30,51`.

--- a/docs/reviews/strict-concurrency-flag-flip-plan-critique-2026-06-27.md
+++ b/docs/reviews/strict-concurrency-flag-flip-plan-critique-2026-06-27.md
@@ -1,0 +1,26 @@
+# Critique: strict-concurrency-flag-flip-2026-06-27.md
+
+**Scope** — One-page review of the Step-5 plan for Issue #19 (final Swift 6 migration polish).
+
+## 1. Under-specified seams (file:line)
+
+- `Package.swift:24-29` — `ReliaBLEMock` target literal already contains `exclude:`. Plan does not state where `swiftSettings:` must be inserted relative to `exclude:`. Implementer could produce invalid Swift syntax.
+- `Documentation.docc/Documentation.md` — plan references the existing `### Concurrency` topic group but gives no line number or exact insertion point for `<doc:Concurrency>`. Placement could break list structure if the group is currently a single bullet.
+- `swift package generate-documentation` gate — no mention of required `--target ReliaBLE` flag (DocC catalog lives only in the production target).
+
+## 2. Contradictions / missing dependencies
+
+None. Plan correctly notes that `swift-tools-version:6.1` already implies Swift 6 + complete concurrency, Willow `LogWriter:Sendable` is accurate, and the two `Task.detached` smoke tests already exist.
+
+## 3. Over-planning risk (cut or simplify)
+
+- “Background (verified current state)” section is ~40 lines of repetition; an implementer will observe the clean build themselves. Reduce to 2–3 bullets.
+- “Open Questions” and “Diagram format” bullets add no actionable decisions for a 4-edit task — delete.
+- Deliverable #3 (`OSLogWriter` comment) is cosmetic only; plan itself says “apply `@unchecked` only if build fails.” Consider dropping the item.
+
+## 4. Questions that change order/correctness
+
+- Must `swift package generate-documentation` succeed with zero warnings, or is the gate only that the new article renders? (Affects whether the step must actually invoke the plugin.)
+- Does `Concurrency.md` require an explicit entry in the DocC catalog index, or does the `<doc:>` link in `Documentation.md` suffice? Answer determines if a second DocC edit is needed.
+
+**Recommendation** — Trim verbosity and the two open-question items; add one clarifying sentence on `swiftSettings` placement and the exact insertion point in `Documentation.md`. The plan is otherwise minimal and correct.


### PR DESCRIPTION
Mark ReliaBLEConfig Sendable, and add DocC concurrency guide.

Make Swift 6 language mode and complete strict concurrency explicit in Package.swift for the ReliaBLE and ReliaBLEMock targets rather than relying on the swift-tools-version default, mark ReliaBLEConfig as Sendable, and document the actor isolation contract in a new DocC Concurrency article. Also record the planning and critique notes for this step of the Swift 6 migration.

Closes #19