### PR TITLE
Demo: route SwiftData writes through background DeviceStoreActor (#20)

### DIFF
--- a/Demo/AGENTS.md
+++ b/Demo/AGENTS.md
@@ -42,7 +42,7 @@ Scheme: **"ReliaBLE Demo"**.
 
 `ReliaBLE Demo.xcodeproj` lives at `Demo/ReliaBLE Demo/ReliaBLE Demo.xcodeproj`. The app is a 3-tab SwiftUI app:
 
-- **Central** (`Central/`) — uses `ReliaBLEManager` (the library) to scan, surfaces discoveries into a SwiftData store. `CentralView` subscribes to the library's `AsyncStream` surfaces in `.task { for await … }` loops; `CentralViewModel` holds UI state and BLE actions only. All SwiftData writes go through `DeviceStoreActor` (`@ModelActor`). State observed via `@Observable`.
+- **Central** (`Central/`) — uses `ReliaBLEManager` (the library) to scan, surfaces discoveries into a SwiftData store. `CentralView` subscribes to the library's `AsyncStream` surfaces in `.task { for await … }` loops; `CentralViewModel` holds UI state and BLE actions only. All SwiftData writes go through `DeviceStoreActor` (manual `ModelActor` conformance). State observed via `@Observable`.
 - **Peripheral** (`Peripheral/`) — uses raw `CBPeripheralManager` directly (not the library — the library doesn't yet expose peripheral mode). This is intentional; the demo shows both sides of BLE even though only the central side flows through ReliaBLE.
 - **Settings** (`Settings/`) — app-level toggles.
 

--- a/Demo/AGENTS.md
+++ b/Demo/AGENTS.md
@@ -42,7 +42,7 @@ Scheme: **"ReliaBLE Demo"**.
 
 `ReliaBLE Demo.xcodeproj` lives at `Demo/ReliaBLE Demo/ReliaBLE Demo.xcodeproj`. The app is a 3-tab SwiftUI app:
 
-- **Central** (`Central/`) — uses `ReliaBLEManager` (the library) to scan, surfaces discoveries into a SwiftData store. `CentralViewModel` is the only place the library's Combine publishers are subscribed. State observed via `@Observable`.
+- **Central** (`Central/`) — uses `ReliaBLEManager` (the library) to scan, surfaces discoveries into a SwiftData store. `CentralView` subscribes to the library's `AsyncStream` surfaces in `.task { for await … }` loops; `CentralViewModel` holds UI state and BLE actions only. All SwiftData writes go through `DeviceStoreActor` (`@ModelActor`). State observed via `@Observable`.
 - **Peripheral** (`Peripheral/`) — uses raw `CBPeripheralManager` directly (not the library — the library doesn't yet expose peripheral mode). This is intentional; the demo shows both sides of BLE even though only the central side flows through ReliaBLE.
 - **Settings** (`Settings/`) — app-level toggles.
 
@@ -50,7 +50,7 @@ Scheme: **"ReliaBLE Demo"**.
 
 - `ReliaBLE_DemoApp.swift` constructs a single `ReliaBLEManager` with `loggingEnabled = true` and injects it via a custom `EnvironmentKey` (`@Environment(\.bleManager)`).
 - There's also a `BLEManagerKey.defaultValue` for previews — keep that working when changing the env injection.
-- A `ModelContainer` for `Device` and `DiscoveryEvent` is set on the root scene. `CentralViewModel` writes both kinds of records as the library emits events.
+- A `ModelContainer` for `Device` and `DiscoveryEvent` is set on the root scene. `CentralView` creates a `DeviceStoreActor` off the main thread via `DeviceStoreActor.create(container:)` and routes all SwiftData writes through it as the library emits events. Reads stay on `@MainActor` via `@Query`.
 
 ## Swift Concurrency
 
@@ -58,8 +58,12 @@ The library is built with Swift 6 and **complete concurrency checking**. Therefo
 
 ### SwiftData models
 
-- `Device` — one row per unique discovered peripheral (by `ReliaBLE.Peripheral.id`), updated on each `discoveredPeripherals` publisher tick.
-- `DiscoveryEvent` — one row per raw advertisement (every `peripheralDiscoveries` event). Grows quickly; "Clear All Data" in the Central view nukes both tables.
+- `Device` — one row per unique discovered peripheral (by `ReliaBLE.Peripheral.id`), updated on each `discoveredPeripherals` stream tick via `DeviceStoreActor.syncDevices`.
+- `DiscoveryEvent` — one row per raw advertisement (every `peripheralDiscoveries` event), inserted via `DeviceStoreActor.insertDiscovery`. Grows quickly; "Clear All Data" in the Central view nukes both tables.
+
+### Off-main persistence pattern
+
+`DeviceStoreActor` is the canonical pattern for library consumers: hold `ReliaBLEManager` on the main actor, consume `AsyncStream`s in `.task`, and `await` the store for every SwiftData write. See the file-level comment in `Central/DeviceStoreActor.swift`.
 
 ## Don't
 

--- a/Demo/ReliaBLE Demo/ReliaBLE Demo/Central/CentralView.swift
+++ b/Demo/ReliaBLE Demo/ReliaBLE Demo/Central/CentralView.swift
@@ -33,17 +33,17 @@ import ReliaBLE
 struct CentralView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.bleManager) private var reliaBLE
-    
+
     @Query private var discoveries: [DiscoveryEvent]
     @Query private var devices: [Device]
-    
+
     @State private var viewModel = CentralViewModel()
     @State private var selectedView: String = "Devices"
-    
+
     var body: some View {
         NavigationSplitView {
             Text("ReliaBLE state: \(viewModel.currentState.description)")
-            
+
             if case BluetoothState.unauthorized(let authState) = viewModel.currentState, authState == .notDetermined {
                 Button("Authorize Bluetooth") {
                     viewModel.authorizeBluetooth()
@@ -53,7 +53,7 @@ struct CentralView: View {
                 TextField("Enter service UUIDs (comma-separated)", text: $viewModel.servicesInput)
                     .textFieldStyle(.roundedBorder)
                     .padding()
-                
+
                 Button("Start Scanning") {
                     viewModel.startScanning()
                 }
@@ -64,14 +64,14 @@ struct CentralView: View {
                 }
                 .buttonStyle(.bordered)
             }
-            
+
             Picker("Select View", selection: $selectedView) {
                 Text("Devices").tag("Devices")
                 Text("Discoveries").tag("Discoveries")
             }
             .pickerStyle(SegmentedPickerStyle())
             .padding()
-            
+
             Group {
                 if selectedView == "Devices" {
                     deviceList
@@ -94,26 +94,31 @@ struct CentralView: View {
         } detail: {
             Text("Select a device")
         }
-        .onAppear {
-            viewModel.setDependencies(modelContext: modelContext, reliaBLE: reliaBLE)
-        }
         .task {
-            for await state in reliaBLE.state {
-                viewModel.updateState(state)
-            }
-        }
-        .task {
-            for await discoveryEvent in reliaBLE.peripheralDiscoveries {
-                viewModel.insertDiscovery(discoveryEvent, into: modelContext)
-            }
-        }
-        .task {
-            for await peripherals in reliaBLE.discoveredPeripherals {
-                viewModel.syncDevices(peripherals, into: modelContext)
+            let manager = reliaBLE
+            let store = await DeviceStoreActor.create(container: modelContext.container)
+            viewModel.setDependencies(deviceStore: store, reliaBLE: manager)
+
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask {
+                    for await state in manager.state {
+                        await viewModel.updateState(state)
+                    }
+                }
+                group.addTask {
+                    for await discoveryEvent in manager.peripheralDiscoveries {
+                        await store.insertDiscovery(discoveryEvent)
+                    }
+                }
+                group.addTask {
+                    for await peripherals in manager.discoveredPeripherals {
+                        await store.syncDevices(peripherals)
+                    }
+                }
             }
         }
     }
-    
+
     private var deviceList: some View {
         List {
             ForEach(devices) { device in
@@ -126,12 +131,12 @@ struct CentralView: View {
                 }
             }
             .onDelete { offsets in
-                let itemsToDelete = offsets.map { devices[$0] }
-                viewModel.deleteDevices(itemsToDelete)
+                let ids = offsets.map { devices[$0].persistentModelID }
+                viewModel.deleteDevices(ids: ids)
             }
         }
     }
-    
+
     private var discoveriesList: some View {
         List {
             ForEach(discoveries) { discoveryEvent in
@@ -144,8 +149,8 @@ struct CentralView: View {
                 }
             }
             .onDelete { offsets in
-                let itemsToDelete = offsets.map { discoveries[$0] }
-                viewModel.deleteDiscoveries(itemsToDelete)
+                let ids = offsets.map { discoveries[$0].persistentModelID }
+                viewModel.deleteDiscoveries(ids: ids)
             }
         }
     }

--- a/Demo/ReliaBLE Demo/ReliaBLE Demo/Central/CentralViewModel.swift
+++ b/Demo/ReliaBLE Demo/ReliaBLE Demo/Central/CentralViewModel.swift
@@ -33,101 +33,54 @@ import ReliaBLE
 @Observable class CentralViewModel {
     var currentState: BluetoothState = .unknown
     var servicesInput = ""
-    
-    private var modelContext: ModelContext?
+
+    private var deviceStore: DeviceStoreActor?
     private var reliaBLE: ReliaBLEManager?
-    
-    func setDependencies(modelContext: ModelContext, reliaBLE: ReliaBLEManager) {
-        self.modelContext = modelContext
+
+    func setDependencies(deviceStore: DeviceStoreActor, reliaBLE: ReliaBLEManager) {
+        self.deviceStore = deviceStore
         self.reliaBLE = reliaBLE
     }
-    
+
     // MARK: - Stream Handlers
     //
-    // Fed by the `.task { for await … }` loops in `CentralView`. Each handler runs on the main
-    // actor before touching `@Observable` state or SwiftData.
-    
+    // Fed by the `.task { for await … }` loops in `CentralView`. Only UI state updates
+    // run on the main actor; SwiftData writes go through `DeviceStoreActor`.
+
     @MainActor
     func updateState(_ state: BluetoothState) {
         currentState = state
     }
-    
-    @MainActor
-    func insertDiscovery(_ discoveryEvent: PeripheralDiscoveryEvent, into modelContext: ModelContext) {
-        let event = DiscoveryEvent(
-            peripheralIdentifier: discoveryEvent.id.uuidString,
-            name: discoveryEvent.name ?? "Unknown",
-            rssi: discoveryEvent.rssi,
-            timestamp: Date()
-        )
-        modelContext.insert(event)
-        try? modelContext.save()
-    }
-    
-    @MainActor
-    func syncDevices(_ peripherals: [Peripheral], into modelContext: ModelContext) {
-        do {
-            let allDevices = try modelContext.fetch(FetchDescriptor<Device>())
-            for peripheral in peripherals {
-                if let existingDevice = allDevices.first(where: { $0.id == peripheral.id }) {
-                    existingDevice.name = peripheral.name
-                    existingDevice.lastSeen = peripheral.lastSeen
-                } else {
-                    let newDevice = Device(id: peripheral.id, name: peripheral.name, lastSeen: Date())
-                    modelContext.insert(newDevice)
-                }
-            }
-            try modelContext.save()
-        } catch {
-            print("Error fetching devices: \(error)")
-        }
-    }
-    
+
     func authorizeBluetooth() {
         Task { try? await reliaBLE?.authorizeBluetooth() }
     }
-    
+
     func startScanning() {
         let services = parseServices(from: servicesInput)
         Task { await reliaBLE?.startScanning(services: services) }
     }
-    
+
     func stopScanning() {
         Task { await reliaBLE?.stopScanning() }
     }
-    
+
     func clearAllData() {
-        guard let modelContext = modelContext else { return }
-        
-        do {
-            let discoveryDescriptor = FetchDescriptor<DiscoveryEvent>(sortBy: [])
-            let discoveries = try modelContext.fetch(discoveryDescriptor)
-            discoveries.forEach { modelContext.delete($0) }
-            
-            let deviceDescriptor = FetchDescriptor<Device>(sortBy: [])
-            let devices = try modelContext.fetch(deviceDescriptor)
-            devices.forEach { modelContext.delete($0) }
-            
-            try modelContext.save()
-        } catch {
-            print("Failed to clear data: \(error)")
-        }
+        Task { await deviceStore?.clearAll() }
     }
-    
-    func deleteDiscoveries(_ items: [DiscoveryEvent]) {
-        items.forEach { modelContext?.delete($0) }
-        try? modelContext?.save()
+
+    func deleteDiscoveries(ids: [PersistentIdentifier]) {
+        Task { await deviceStore?.deleteDiscoveries(ids: ids) }
     }
-    
-    func deleteDevices(_ items: [Device]) {
-        items.forEach { modelContext?.delete($0) }
-        try? modelContext?.save()
+
+    func deleteDevices(ids: [PersistentIdentifier]) {
+        Task { await deviceStore?.deleteDevices(ids: ids) }
     }
-    
+
     private func parseServices(from input: String) -> [CBUUID]? {
         let components = input.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
         let uuids = components.filter { !$0.isEmpty }.map { CBUUID(string: $0) }
-        
+
         return uuids.isEmpty ? nil : uuids
     }
 }

--- a/Demo/ReliaBLE Demo/ReliaBLE Demo/Central/DeviceStoreActor.swift
+++ b/Demo/ReliaBLE Demo/ReliaBLE Demo/Central/DeviceStoreActor.swift
@@ -44,10 +44,12 @@ actor DeviceStoreActor: ModelActor {
         self.modelContainer = modelContainer
     }
 
-    /// Creates a background-isolated store. Call from a nonisolated `async` context — not from
-    /// `@MainActor` — so `ModelActor` does not inherit main-thread execution.
+    /// Creates a background-isolated store. Safe to call from `@MainActor` (e.g. SwiftUI `.task`);
+    /// construction is explicitly detached so `ModelActor` does not inherit main-thread execution.
     static nonisolated func create(container: ModelContainer) async -> DeviceStoreActor {
-        DeviceStoreActor(modelContainer: container)
+        await Task.detached {
+            DeviceStoreActor(modelContainer: container)
+        }.value
     }
 
     func insertDiscovery(_ discoveryEvent: PeripheralDiscoveryEvent) {
@@ -73,7 +75,7 @@ actor DeviceStoreActor: ModelActor {
                     existingDevice.name = peripheral.name
                     existingDevice.lastSeen = peripheral.lastSeen
                 } else {
-                    let newDevice = Device(id: peripheral.id, name: peripheral.name, lastSeen: Date())
+                    let newDevice = Device(id: peripheral.id, name: peripheral.name, lastSeen: peripheral.lastSeen)
                     modelContext.insert(newDevice)
                 }
             }

--- a/Demo/ReliaBLE Demo/ReliaBLE Demo/Central/DeviceStoreActor.swift
+++ b/Demo/ReliaBLE Demo/ReliaBLE Demo/Central/DeviceStoreActor.swift
@@ -1,0 +1,129 @@
+//
+//  DeviceStoreActor.swift
+//  ReliaBLE Demo
+//
+//  Copyright (c) 2025 Five3 Apps, LLC <justin@five3apps.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import Foundation
+import SwiftData
+
+import ReliaBLE
+
+/// Canonical off-main SwiftData persistence for ReliaBLE discovery events.
+///
+/// Copy this pattern when building a real app:
+/// - Hold `ReliaBLEManager` on the main actor (or inject via SwiftUI environment).
+/// - Consume `AsyncStream` surfaces in `.task { for await … }`.
+/// - Create the store with ``create(container:)`` so SwiftData's `ModelActor` runs off the main thread.
+/// - Route every SwiftData write through this actor; keep reads on `@MainActor` via `@Query`.
+actor DeviceStoreActor: ModelActor {
+    nonisolated let modelExecutor: any ModelExecutor
+    nonisolated let modelContainer: ModelContainer
+
+    init(modelContainer: ModelContainer) {
+        let modelContext = ModelContext(modelContainer)
+        self.modelExecutor = DefaultSerialModelExecutor(modelContext: modelContext)
+        self.modelContainer = modelContainer
+    }
+
+    /// Creates a background-isolated store. Call from a nonisolated `async` context — not from
+    /// `@MainActor` — so `ModelActor` does not inherit main-thread execution.
+    static nonisolated func create(container: ModelContainer) async -> DeviceStoreActor {
+        DeviceStoreActor(modelContainer: container)
+    }
+
+    func insertDiscovery(_ discoveryEvent: PeripheralDiscoveryEvent) {
+        assertWritesOffMainThread()
+
+        let event = DiscoveryEvent(
+            peripheralIdentifier: discoveryEvent.id.uuidString,
+            name: discoveryEvent.name ?? "Unknown",
+            rssi: discoveryEvent.rssi,
+            timestamp: Date()
+        )
+        modelContext.insert(event)
+        try? modelContext.save()
+    }
+
+    func syncDevices(_ peripherals: [Peripheral]) {
+        assertWritesOffMainThread()
+
+        do {
+            let allDevices = try modelContext.fetch(FetchDescriptor<Device>())
+            for peripheral in peripherals {
+                if let existingDevice = allDevices.first(where: { $0.id == peripheral.id }) {
+                    existingDevice.name = peripheral.name
+                    existingDevice.lastSeen = peripheral.lastSeen
+                } else {
+                    let newDevice = Device(id: peripheral.id, name: peripheral.name, lastSeen: Date())
+                    modelContext.insert(newDevice)
+                }
+            }
+            try modelContext.save()
+        } catch {
+            print("Error fetching devices: \(error)")
+        }
+    }
+
+    func clearAll() {
+        assertWritesOffMainThread()
+
+        do {
+            let discoveries = try modelContext.fetch(FetchDescriptor<DiscoveryEvent>())
+            discoveries.forEach { modelContext.delete($0) }
+
+            let devices = try modelContext.fetch(FetchDescriptor<Device>())
+            devices.forEach { modelContext.delete($0) }
+
+            try modelContext.save()
+        } catch {
+            print("Failed to clear data: \(error)")
+        }
+    }
+
+    func deleteDiscoveries(ids: [PersistentIdentifier]) {
+        assertWritesOffMainThread()
+
+        for id in ids {
+            if let event = modelContext.model(for: id) as? DiscoveryEvent {
+                modelContext.delete(event)
+            }
+        }
+        try? modelContext.save()
+    }
+
+    func deleteDevices(ids: [PersistentIdentifier]) {
+        assertWritesOffMainThread()
+
+        for id in ids {
+            if let device = modelContext.model(for: id) as? Device {
+                modelContext.delete(device)
+            }
+        }
+        try? modelContext.save()
+    }
+
+    private func assertWritesOffMainThread() {
+        #if DEBUG
+        assert(!Thread.isMainThread, "SwiftData writes must run off the main thread")
+        #endif
+    }
+}

--- a/docs/plans/demo-background-swiftdata-2026-06-27.md
+++ b/docs/plans/demo-background-swiftdata-2026-06-27.md
@@ -1,0 +1,113 @@
+# Demo: exercise ReliaBLE from a background-actor SwiftData stack: Plan
+*Issue #20 · 2026-06-27*
+
+## Goal
+
+Refactor the Demo app's SwiftData layer so **all writes** run on a background `ModelActor`, while reads stay on `@MainActor` via `@Query`. The Demo then exercises `ReliaBLEManager` across actor boundaries at PR-time — catching inadvertent `@MainActor` creep in the library — and doubles as a concrete off-main persistence pattern for consumers. No library changes.
+
+Tracked under parent #10 as a **Preventive Measure** in `docs/investigations/swift6-concurrency-audit-2026-05-13.md` (not a numbered migration step). Depends on the Step 4 `Sendable` façade (#18) and `AsyncStream` surfaces (#12) being in place; both are merged on the current branch.
+
+## Background (verified pre-change state)
+
+**Library (ready — no work needed):**
+- `ReliaBLEManager` is `public final class ReliaBLEManager: Sendable`, nonisolated, forwarding to internal `BluetoothActor.shared` (`ReliaBLEManager.swift:38`).
+- Three event surfaces return fresh per-subscriber `AsyncStream`s: `state`, `peripheralDiscoveries`, `discoveredPeripherals` (`ReliaBLEManager.swift:84–120`).
+- Element types `Peripheral`, `PeripheralDiscoveryEvent`, `BluetoothState` are `Sendable` value types — safe to hand across isolation domains from stream loops.
+- DocC `Concurrency.md` documents the isolation contract for consumers.
+
+**Demo consumption (`Demo/ReliaBLE Demo/.../Central/`) — the problem:**
+- `CentralView` already consumed streams via three `.task { for await … }` blocks (post-Step 3), but persistence still ran on `@MainActor`.
+- `CentralViewModel.insertDiscovery(_:into:)` and `syncDevices(_:into:)` were `@MainActor` methods that took a `ModelContext` and wrote directly inside the stream loops (`CentralViewModel.swift:55–84`; wired from `CentralView.swift:105–114`).
+- `clearAllData`, swipe-delete (`deleteDiscoveries` / `deleteDevices`) also used a stored `ModelContext` on the view-model.
+- `@Query` in `CentralView` handled reads on main — this part was already correct and stays.
+- `ReliaBLE_DemoApp.swift` provides a single shared `ModelContainer` via `.modelContainer(sharedModelContainer)` and injects `ReliaBLEManager` via `@Environment(\.bleManager)`.
+- Demo builds with `SWIFT_STRICT_CONCURRENCY = complete` (`project.pbxproj`).
+
+**SwiftData models (unchanged):**
+- `Device` — one row per unique discovered peripheral (keyed by `Peripheral.id`), upserted on each `discoveredPeripherals` tick.
+- `DiscoveryEvent` — one row per raw advertisement (`peripheralDiscoveries` event).
+
+**Out of scope:** library test-target background-actor smoke test (Step 5 / #19); Peripheral tab (no SwiftData).
+
+## Approach
+
+Introduce `DeviceStoreActor` — a `ModelActor` that owns every SwiftData write. `CentralView` creates it off the main thread, then runs three concurrent stream loops: state → `@MainActor` view-model; discoveries and peripheral list → store.
+
+```
+CentralView (@MainActor reads via @Query)
+    │
+    ├─ .task ──► DeviceStoreActor.create(container:)   [off-main creation]
+    │                │
+    │                ├─ insertDiscovery / syncDevices / delete* / clearAll
+    │                └─ modelContext.save()
+    │
+    ├─ ReliaBLEManager.state ──────────► CentralViewModel.updateState (@MainActor)
+    ├─ ReliaBLEManager.peripheralDiscoveries ──► store.insertDiscovery
+    └─ ReliaBLEManager.discoveredPeripherals ──► store.syncDevices
+```
+
+**`DeviceStoreActor` design:**
+- Manual `ModelActor` conformance (not the `@ModelActor` macro) with an explicit `init(modelContainer:)` and `nonisolated let modelExecutor` / `modelContainer` — the macro's synthesized initializer is not accessible from outside the type, which blocked environment-key and preview construction.
+- `static nonisolated func create(container:) async -> DeviceStoreActor` — **critical**: SwiftData `ModelActor` inherits the thread of its creation context. Initializing on `@MainActor` (e.g. in `App.init` or a synchronous environment default) pins writes to the main thread despite the actor label. The factory must be called from a `nonisolated async` context so the actor actually runs in the background.
+- Write methods: `insertDiscovery`, `syncDevices`, `clearAll`, `deleteDiscoveries(ids:)`, `deleteDevices(ids:)`. Swipe-delete passes `PersistentIdentifier` (Sendable) rather than `@Model` class instances.
+- `#if DEBUG` `assert(!Thread.isMainThread)` in every write method — acceptance-criteria guard.
+- File-level doc comment pointing consumers at this as the canonical off-main persistence pattern.
+
+**`CentralView` pipeline:**
+- One `.task` block: capture `let manager = reliaBLE` (avoids MainActor-isolated environment access inside `TaskGroup` children under strict concurrency), `await DeviceStoreActor.create(container: modelContext.container)`, wire `viewModel.setDependencies`, then `withTaskGroup` running three concurrent `for await` loops.
+- `@Environment(\.modelContext)` retained **only** to reach `modelContext.container` for store creation; no direct writes through it.
+- `@Query` unchanged for Devices / Discoveries lists.
+
+**`CentralViewModel` slim-down:**
+- Drop `modelContext` storage and all `@MainActor` persistence methods.
+- Keep `@MainActor updateState` for `@Observable` UI properties.
+- Keep fire-and-forget BLE actions (`authorizeBluetooth`, `startScanning`, `stopScanning`).
+- `clearAllData` / delete helpers wrap `Task { await deviceStore?.… }`.
+
+**Documentation:** inline comment in `DeviceStoreActor.swift` + update `Demo/AGENTS.md` concurrency / app-structure sections.
+
+## Work Items
+
+Demo-only; library untouched. Build via XcodeBuildMCP (workspace `ReliaBLE.xcworkspace`, scheme `ReliaBLE Demo`).
+
+1. **`DeviceStoreActor.swift` — new file.** `actor DeviceStoreActor: ModelActor` under `Central/`. Move write logic from the old `CentralViewModel` persistence methods. Add `create(container:)` factory and debug thread asserts. PBXFileSystemSynchronizedRootGroup auto-includes the file. *(Build may fail until items 2–3 land.)*
+
+2. **`CentralViewModel.swift` — slim down.** Remove `modelContext`, `insertDiscovery`, `syncDevices`. Change `setDependencies` to `(deviceStore:reliaBLE:)`. Route `clearAllData` / delete through `deviceStore` via `Task { await … }`. Keep `updateState` as the sole `@MainActor` handler.
+
+3. **`CentralView.swift` — rewire pipeline.** Replace three separate `.task` loops + `onAppear` modelContext wiring with the single `.task` + `withTaskGroup` pattern. Swipe-delete passes `persistentModelID`. Capture `reliaBLE` into a local `manager` before spawning child tasks.
+
+4. **`Demo/AGENTS.md` — document pattern.** Update App structure and Swift Concurrency sections: `DeviceStoreActor` owns writes; `CentralViewModel` owns UI state + BLE actions; `@Query` owns reads; store created via `create(container:)`.
+
+5. **Verify.**
+   - `ReliaBLE Demo` scheme builds clean under `SWIFT_STRICT_CONCURRENCY = complete` (zero warnings).
+   - Debug asserts fire during scanning (writes off-main).
+   - UX unchanged: Devices / Discoveries lists update live; Clear All and swipe-delete work.
+   - No `@MainActor` annotation added to any library public type to make the Demo compile (regression guard).
+
+## Decisions (resolved at implementation)
+
+1. **Manual `ModelActor` conformance, not `@ModelActor` macro.** The macro synthesizes an initializer that is not constructible from `EnvironmentKey.defaultValue`, `ReliaBLE_DemoApp` property initializers, or `#Preview` — build error: *"'DeviceStoreActor' cannot be constructed because it has no accessible initializers."* Manual expansion (`modelExecutor` + `modelContainer` + `DefaultSerialModelExecutor`) matches the macro output and exposes a public `init(modelContainer:)`.
+
+2. **No `@Environment(\.deviceStore)` injection.** App-level `var deviceStore = DeviceStoreActor(modelContainer: sharedModelContainer)` also fails: (a) `sharedModelContainer` is unavailable in a sibling property initializer, and (b) synchronous main-thread creation defeats the off-main goal. Store is created in `CentralView`'s `.task` via `create(container:)` instead.
+
+3. **Single `.task` + `withTaskGroup` instead of three `.task` blocks.** Guarantees the store exists before stream loops start; runs state / discoveries / peripherals concurrently. Alternative (three independent `.task`s) risks racing on an uninitialized store.
+
+4. **`let manager = reliaBLE` before `TaskGroup`.** `@Environment(\.bleManager)` is MainActor-isolated; child tasks in the group are not. Local capture of the `Sendable` manager avoids Swift 6 errors. Same pattern applies to any future environment-injected `Sendable` service.
+
+5. **Deletes via `PersistentIdentifier`, not model instances.** `@Model` classes are not `Sendable`; passing them into `DeviceStoreActor` from `@MainActor` list handlers would violate strict concurrency. `persistentModelID` is `Sendable` and resolves back to the model inside the actor via `modelContext.model(for:)`.
+
+6. **Docs split: inline comment + `Demo/AGENTS.md`.** Issue asked for README or inline comment; both inline (`DeviceStoreActor.swift` header) and agents doc update were chosen. No standalone `Demo/README.md`.
+
+## Open Questions
+
+None blocking. One item noted for future Demo work:
+- **Fetch perf on `syncDevices`:** current implementation fetches all `Device` rows per `discoveredPeripherals` tick (inherited from pre-refactor code). Fine for a demo; a production app would index by `id` or maintain an in-actor lookup cache.
+
+## References
+
+- Issue #20; parent #10. Related library steps: #12 (AsyncStream), #18 (`Sendable` façade), #19 (strict-concurrency flag / DocC `Concurrency.md`).
+- Audit preventive measure: `docs/investigations/swift6-concurrency-audit-2026-05-13.md` — Preventive Measures ("Cross-actor validation in the Demo"), Tracking table.
+- SwiftData `ModelActor` creation-context behavior: [massicotte.org/model-actor](https://www.massicotte.org/model-actor/) (ModelActor inherits main-thread execution when created on MainActor).
+- Key files: `Demo/ReliaBLE Demo/ReliaBLE Demo/Central/DeviceStoreActor.swift`, `CentralViewModel.swift`, `CentralView.swift`, `ReliaBLE_DemoApp.swift`, `Demo/AGENTS.md`.
+- Library concurrency contract (unchanged): `Sources/ReliaBLE/Documentation.docc/Topics/Concurrency.md`.
+- Prior step plans: `docs/plans/combine-to-asyncstream-2026-06-18.md` (Step 3 — Demo stream consumption), `docs/plans/manager-sendable-collapse-2026-06-23.md` (Step 4 — `Sendable` façade).

--- a/docs/plans/demo-background-swiftdata-2026-06-27.md
+++ b/docs/plans/demo-background-swiftdata-2026-06-27.md
@@ -48,7 +48,7 @@ CentralView (@MainActor reads via @Query)
 
 **`DeviceStoreActor` design:**
 - Manual `ModelActor` conformance (not the `@ModelActor` macro) with an explicit `init(modelContainer:)` and `nonisolated let modelExecutor` / `modelContainer` — the macro's synthesized initializer is not accessible from outside the type, which blocked environment-key and preview construction.
-- `static nonisolated func create(container:) async -> DeviceStoreActor` — **critical**: SwiftData `ModelActor` inherits the thread of its creation context. Initializing on `@MainActor` (e.g. in `App.init` or a synchronous environment default) pins writes to the main thread despite the actor label. The factory must be called from a `nonisolated async` context so the actor actually runs in the background.
+- `static nonisolated func create(container:) async -> DeviceStoreActor` — **critical**: SwiftData `ModelActor` inherits the thread of its creation context. Initializing on `@MainActor` (e.g. in `App.init`, a SwiftUI `.task`, or a synchronous environment default) pins writes to the main thread despite the actor label. The factory wraps construction in `Task.detached` so callers can safely invoke it from any context.
 - Write methods: `insertDiscovery`, `syncDevices`, `clearAll`, `deleteDiscoveries(ids:)`, `deleteDevices(ids:)`. Swipe-delete passes `PersistentIdentifier` (Sendable) rather than `@Model` class instances.
 - `#if DEBUG` `assert(!Thread.isMainThread)` in every write method — acceptance-criteria guard.
 - File-level doc comment pointing consumers at this as the canonical off-main persistence pattern.


### PR DESCRIPTION
Closes #20

## Summary

Refactors the Demo app's Central tab so all SwiftData writes run on a background `ModelActor` (`DeviceStoreActor`), while reads stay on `@MainActor` via `@Query`. The Demo now exercises `ReliaBLEManager` across actor boundaries — catching inadvertent `@MainActor` creep in the library at PR time — and serves as a concrete off-main persistence pattern for consumers.

No library changes.

## What changed

- **`DeviceStoreActor`** — new `ModelActor` owning every SwiftData write (discovery inserts, device upserts, deletes, clear-all). Created off-main via `create(container:)` so SwiftData does not inherit main-thread execution. Debug builds assert writes are not on the main thread.
- **`CentralView`** — single `.task` + `withTaskGroup` runs three concurrent stream loops: `state` → view-model, `peripheralDiscoveries` / `discoveredPeripherals` → store.
- **`CentralViewModel`** — slimmed to UI state (`updateState`) and BLE actions only; delete/clear route through the store.
- **`Demo/AGENTS.md`** — documents the new architecture.
- **`docs/plans/demo-background-swiftdata-2026-06-27.md`** — implementation plan.

## Verification

- ReliaBLE Demo builds clean under `SWIFT_STRICT_CONCURRENCY = complete` (zero warnings).
- No `@MainActor` annotations added to any library public type.

## Plan

`docs/plans/demo-background-swiftdata-2026-06-27.md`