### PR TITLE
CI: Build DocC catalog on every PR (#22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docc:
+    name: DocC catalog
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+
+      - name: Verify Swift version
+        run: swift --version
+
+      - name: Build DocC catalog
+        run: swift package generate-documentation --target ReliaBLE --warnings-as-errors
+
+      - name: Upload DocC archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ReliaBLE.doccarchive
+          path: .build/plugins/Swift-DocC/outputs/ReliaBLE.doccarchive
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,12 @@ jobs:
       - name: Build DocC catalog
         run: swift package generate-documentation --target ReliaBLE --warnings-as-errors
 
+      - name: Archive DocC output
+        run: ditto -c -k --sequesterRsrc --keepParent .build/plugins/Swift-DocC/outputs/ReliaBLE.doccarchive ReliaBLE.doccarchive.zip
+
       - name: Upload DocC archive
         uses: actions/upload-artifact@v4
         with:
           name: ReliaBLE.doccarchive
-          path: .build/plugins/Swift-DocC/outputs/ReliaBLE.doccarchive
+          path: ReliaBLE.doccarchive.zip
           if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,20 +18,29 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+        run: |
+          if [ ! -d /Applications/Xcode_16.4.app ]; then
+            echo "Xcode 16.4 not found. Installed Xcode versions:"
+            ls /Applications | grep Xcode || true
+            exit 1
+          fi
+          sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Verify Swift version
         run: swift --version
 
       - name: Build DocC catalog
-        run: swift package generate-documentation --target ReliaBLE --warnings-as-errors
+        run: |
+          swift package --allow-writing-to-directory ./docc-output \
+            generate-documentation --target ReliaBLE --warnings-as-errors \
+            --output-path ./docc-output
 
       - name: Archive DocC output
-        run: ditto -c -k --sequesterRsrc --keepParent .build/plugins/Swift-DocC/outputs/ReliaBLE.doccarchive ReliaBLE.doccarchive.zip
+        run: ditto -c -k --sequesterRsrc --keepParent docc-output ReliaBLE-docs.zip
 
       - name: Upload DocC archive
         uses: actions/upload-artifact@v4
         with:
-          name: ReliaBLE.doccarchive
-          path: ReliaBLE.doccarchive.zip
+          name: ReliaBLE-docs
+          path: ReliaBLE-docs.zip
           if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Packages/
 .swiftpm
 
 .build/
+docc-output/
 DerivedData/
 
 # CocoaPods

--- a/Sources/ReliaBLE/Models/Peripheral.swift
+++ b/Sources/ReliaBLE/Models/Peripheral.swift
@@ -66,10 +66,10 @@ public class Peripheral: Identifiable, Hashable {
     /// The timestamp when the peripheral was last seen
     public internal(set) var lastSeen: Date?
     
-    /// Create a peripheral with a unique identifier and optional CoreBluetooth peripheral data. The integrating app
-    /// should use this initializer to create a `Peripheral` instance when it has a unique identifier for a peripheral
-    /// but has not yet discovered the peripheral with CoreBluetooth. ReliaBLE will update the instance
-    /// with CoreBluetooth data when the peripheral is discovered.
+    /// Creates a peripheral with a unique identifier and optional CoreBluetooth discovery data.
+    ///
+    /// Prefer observing ``ReliaBLEManager/discoveredPeripherals`` for devices discovered during scanning.
+    /// ReliaBLE updates only the ``Peripheral`` instances it manages internally and emits through that publisher.
     /// - Parameters:
     ///  - id: Unique identifier for the peripheral as set by the integrating app.
     ///  - peripheral: Reference to the CoreBluetooth `CBPeripheral` object

--- a/Sources/ReliaBLE/Models/Peripheral.swift
+++ b/Sources/ReliaBLE/Models/Peripheral.swift
@@ -68,7 +68,7 @@ public class Peripheral: Identifiable, Hashable {
     
     /// Create a peripheral with a unique identifier and optional CoreBluetooth peripheral data. The integrating app
     /// should use this initializer to create a `Peripheral` instance when it has a unique identifier for a peripheral
-    /// but has not yet discovered the peripheral with CoreBluetooth. The ``PeripheralManager`` will update the instance
+    /// but has not yet discovered the peripheral with CoreBluetooth. ReliaBLE will update the instance
     /// with CoreBluetooth data when the peripheral is discovered.
     /// - Parameters:
     ///  - id: Unique identifier for the peripheral as set by the integrating app.


### PR DESCRIPTION
## Summary

Adds the first job to the CI pipeline scaffold: a DocC generation check that runs on every PR and push to `master`.

- Runs `swift package generate-documentation --target ReliaBLE --warnings-as-errors`
- Fails the build on broken DocC anchors or missing documented symbols
- Uploads `ReliaBLE.doccarchive.zip` as a PR artifact for reviewer preview

This is the DocC sub-issue of #21 (full CI). Build/test/lint jobs will be added to the same workflow in a follow-up.

Also fixes a pre-existing DocC failure on `master`: the public `Peripheral` initializer doc comment linked to the internal `PeripheralManager` type.

## How to preview docs from a PR

1. Open the PR checks → **DocC catalog** job → **Artifacts**
2. Download and unzip `ReliaBLE.doccarchive.zip`
3. Open `ReliaBLE.doccarchive` in Xcode via **File → Open Documentation Catalog**, or use DocC preview

Closes #22