### PR TITLE
Add Codecov code coverage badge and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,31 @@ jobs:
         run: swift build
 
       - name: Test
-        run: swift test
+        run: swift test --enable-code-coverage
+
+      # Export coverage as lcov, restricted to library sources. The
+      # -ignore-filename-regex drops test files, the Demo app, and all
+      # dependency/build-artifact code so the badge reflects library coverage
+      # only. Paths are absolute in llvm-cov output, so these fragments match
+      # anywhere in the checkout.
+      - name: Export code coverage
+        run: |
+          BIN_PATH="$(swift build --show-bin-path)"
+          XCTEST="$(find "${BIN_PATH}" -maxdepth 1 -name '*.xctest' | head -1)"
+          COV_BIN="${XCTEST}/Contents/MacOS/$(basename "${XCTEST}" .xctest)"
+          xcrun llvm-cov export \
+            -format=lcov \
+            -instr-profile "${BIN_PATH}/codecov/default.profdata" \
+            "${COV_BIN}" \
+            -ignore-filename-regex='(\.build|Tests|Demo)/' \
+            > coverage.lcov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.lcov
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   docc:
     name: DocC catalog

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ReliaBLE
 
-[![CI](https://github.com/Five3Apps/ReliaBLE/actions/workflows/ci.yml/badge.svg)](https://github.com/Five3Apps/ReliaBLE/actions/workflows/ci.yml)
+[![CI](https://github.com/Five3Apps/ReliaBLE/actions/workflows/ci.yml/badge.svg)](https://github.com/Five3Apps/ReliaBLE/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/Five3Apps/ReliaBLE/branch/master/graph/badge.svg)](https://codecov.io/gh/Five3Apps/ReliaBLE)
 
 A reliable, modern, and easy-to-use Swift package for apps that talk to Bluetooth Low Energy (BLE) peripherals.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+# Codecov configuration for ReliaBLE.
+#
+# Coverage is measured for the library sources only. The CI workflow already
+# filters test files, the Demo app, and dependencies out of the uploaded lcov
+# report via llvm-cov's -ignore-filename-regex; the ignore list below is a
+# second line of defence so those paths never count toward coverage even if the
+# export filter changes.
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+
+ignore:
+  - "Tests"
+  - "Demo"
+  - "**/.build/**"
+
+comment:
+  layout: "reach, diff, files"
+  require_changes: true


### PR DESCRIPTION
Adds a code coverage badge to the README next to the existing CI badge, wired into the existing test runner via Codecov.

## Changes

- **`.github/workflows/ci.yml`** — coverage tied into the existing `build-test` job:
  - `swift test` → `swift test --enable-code-coverage`
  - New **Export code coverage** step converts the SPM `.profdata` to an lcov report via `xcrun llvm-cov export`, using `-ignore-filename-regex='(\.build|Tests|Demo)/'` to exclude test files, the Demo app, and all dependency/build-artifact code.
  - New **Upload coverage to Codecov** step (`codecov/codecov-action@v5`) uploads `coverage.lcov`. `fail_ci_if_error: false` so CI won't break before Codecov is configured.
- **`codecov.yml`** — second line of defence for the ignore paths (`Tests`, `Demo`, `.build`), plus `auto`-target project/patch status and comment behavior.
- **`README.md`** — Codecov badge added alongside the CI badge.

## Coverage scope

Tests run against `ReliaBLEMock`, which shares the `Sources/ReliaBLE/` source tree, so coverage maps to the library sources. Per the three-target mock design, `CBCentralManagerFactory.swift` is excluded from the mock target and won't appear in coverage, since the production `ReliaBLE` target isn't the one under test — expected given the architecture.

## Follow-up required

For uploads and the badge to work, the repo must be enabled on [codecov.io](https://codecov.io) and a repository upload token added as a GitHub Actions secret named `CODECOV_TOKEN`. Until then the badge shows "unknown" and CI stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HBDhen1gvude7r9Yv4FPzP)_